### PR TITLE
Ajout gestion modifier ETAT et darkvision

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -73,6 +73,7 @@
         "critrange": "Critique",
         "rank": "Rang",
         "add": "Ajouter",
+        "darkvision": "Vision dans le noir",
         "sendToChat": "Envoyer sur le chat",
         "edit": "Editer",
         "editItem": "Editer l'objet",
@@ -419,7 +420,8 @@
         "combat": "Combat",
         "attribute": "Attribut",
         "resource": "Ressource",
-        "skill": "Jet de compétence"
+        "skill": "Jet de compétence",
+        "state": "Etat"
       },
       "target": {
         "agi": "Agilité",

--- a/module/applications/sheets/base-actor-sheet.mjs
+++ b/module/applications/sheets/base-actor-sheet.mjs
@@ -22,10 +22,8 @@ export default class CoBaseActorSheet extends ActorSheet {
     context.inventory = this.actor.inventory
     context.unlocked = this.actor.isUnlocked
     context.locked = !this.actor.isUnlocked
-
     // Select options
     context.choiceMoveUnit = SYSTEM.MOVEMENT_UNIT
-
     console.log("Actor Sheet context", context)
     return context
   }

--- a/module/applications/sheets/base-item-sheet.mjs
+++ b/module/applications/sheets/base-item-sheet.mjs
@@ -342,7 +342,7 @@ export default class CoBaseItemSheet extends ItemSheet {
       skill: {
         formula: [{ part: "@atc" }],
         crit: "20",
-        difficulty: "@def",
+        difficulty: "@target.def",
       },
       damage: {
         formula: [{ part: "" }],

--- a/module/config/modifier.mjs
+++ b/module/config/modifier.mjs
@@ -42,6 +42,10 @@ export const MODIFIERS_SUBTYPE = Object.freeze({
     id: "skill",
     label: "CO.modifier.subtype.skill",
   },
+  state: {
+    id: "state",
+    label: "CO.modifier.subtype.state",
+  },
 })
 
 export const MODIFIERS_TARGET = Object.freeze({
@@ -108,5 +112,9 @@ export const MODIFIERS_TARGET = Object.freeze({
   mp: {
     id: "mp",
     label: "CO.label.long.mp",
+  },
+  darkvision: {
+    id: "darkvision",
+    label: "CO.label.long.darkvision",
   },
 })

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -20,12 +20,11 @@ export default class COActor extends Actor {
       const img = SYSTEM.ACTOR_ICONS[this.type]
       this.updateSource({ img })
     }
-
     // Configure prototype token settings
     if (this.type === "character") {
       const prototypeToken = {}
       Object.assign(prototypeToken, {
-        sight: { enabled: true },
+        sight: { enabled: true, visionMode: "basic" },
         actorLink: true,
         disposition: CONST.TOKEN_DISPOSITIONS.FRIENDLY,
       })
@@ -453,7 +452,6 @@ export default class COActor extends Actor {
     const updateModifiers = { _id: newFeature[0].id, "system.modifiers": newModifiers }
 
     await this.updateEmbeddedDocuments("Item", [updateModifiers])
-
     // Create all Paths
     let updatedPathsUuids = []
     for (const path of feature.system.paths) {

--- a/module/helpers.mjs
+++ b/module/helpers.mjs
@@ -50,4 +50,8 @@ export default function registerHandlebarsHelpers() {
     if (actor.isTrainedWithShield(itemId)) return "MAITRISE"
     return "NON MAITRISE"
   })
+  Handlebars.registerHelper("isActionState", function (modifier) {
+    if (modifier.subtype === "state") return true
+    else return false
+  })
 }

--- a/module/models/schemas/resolver.mjs
+++ b/module/models/schemas/resolver.mjs
@@ -48,7 +48,9 @@ export class Resolver extends foundry.abstract.DataModel {
     const actionName = action.label
 
     const skillFormula = this.skill.formula[0].part
-    const crit = this.skill.crit    
+
+    const crit = this.skill.crit
+
     const diffToEvaluate = this.skill.difficulty.match("[0-9]{0,}[d|D][0-9]{1,}")
     let diff = ""
     if (diffToEvaluate) {
@@ -56,7 +58,9 @@ export class Resolver extends foundry.abstract.DataModel {
     } else {
       diff = Utils.evaluate(actor, this.skill.difficulty, item.uuid, true)
     }
-    const skillFormulaToEvaluate = !(skillFormula.match("[0-9]{0,}[d|D][0-9]{1,}")
+
+    const skillFormulaToEvaluate = !skillFormula.match("[0-9]{0,}[d|D][0-9]{1,}")
+
     let skillFormulaEvaluated = skillFormulaToEvaluate ? Utils.evaluate(actor, skillFormula, item.uuid, true) : Utils.evaluateWithDice(actor, skillFormula, item.uuid)
 
     const damageFormula = this.dmg.formula[0].part
@@ -85,6 +89,7 @@ export class Resolver extends foundry.abstract.DataModel {
     const damageFormula = this.dmg.formula[0].part
     const auto = true
     const type = "damage"
+
 
     let damageFormulaEvaluated =
       damageFormula.match("[0-9]{0,}[d|D][0-9]{1,}") ? Utils.evaluateWithDice(actor, damageFormula, item.uuid) : Utils.evaluate(actor, damageFormula, item.uuid)

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -131,6 +131,13 @@ export default class Utils {
           replacedFormula = replacedFormula.replace(shortcut, foundry.utils.getProperty(targetactor, CBL[shortcut]))
         }
       })
+    } else {
+      //Si on a pas ciblé ou si on ne trouve pas la cible
+      Object.keys(CBL).forEach((shortcut) => {
+        if (replacedFormula.includes(shortcut)) {
+          replacedFormula = replacedFormula.replace(shortcut, "")
+        }
+      })
     }
 
     /**
@@ -168,12 +175,12 @@ export default class Utils {
 
     replacedFormula = calculateTotalRank(replacedFormula, "@rang")
     replacedFormula = calculateTotalRank(replacedFormula, "@rank")
-
+    console.log(replacedFormula)
     // Remaining formula
     if (replacedFormula.includes("@")) {
       replacedFormula = replacedFormula.replace("@", "actor.system.")
     }
-
+    console.log(replacedFormula)
     if (withDice) return replacedFormula
     else {
       if (toEvaluate) return eval(replacedFormula)

--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -13,6 +13,17 @@
                     <span class="level adjustable">{{attributes.level}}</span>
                 {{/if}}
             </div>
+            <div class="flexrow" style="margin-top:0.25em;">
+                <div class="adjustment-select flexrow">                    
+                    {{#each actions as |a aid|}}                    
+                        {{#each a.modifiers as |m mid| }}                                                                                              
+                           {{#if (isActionState m)}}                                                         
+                                <span class="adjustment elite trait">{{localize (concat "CO.label.long." m.target)}}</span>
+                          {{/if}}
+                        {{/each}}
+                    {{/each}}
+                </div>
+            </div>
         </header>
         {{!-- Sheet Tab Navigation --}}
         <nav class="sheet-tabs tabs" data-group="primary">


### PR DESCRIPTION
Ajout du modifer "state" et gestion de la vision dans le noir qui modifie le prototype token pour activer la visoon dans le noit. Affiche aussi les etats en haut de la fiche de perso et predn en charge le retrait et l'ajout de capacité avec darkvision