### PR TITLE
fix l'affichage des etats sur la fiche de perso

### DIFF
--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -14,12 +14,14 @@
             </div>
             <div class="flexrow" style="margin-top:0.25em;">
                 <div class="adjustment-select flexrow">                    
-                    {{#each actions as |a aid|}}                    
-                        {{#each a.modifiers as |m mid| }}                                                                                              
-                           {{#if m.isState}}                                                         
-                                <span class="adjustment elite trait">{{localize (concat "CO.label.long." m.target)}}</span>
-                          {{/if}}
-                        {{/each}}
+                    {{#each actions as |a aid|}}  
+                        {{#if a.properties.enabled}}                  
+                            {{#each a.modifiers as |m mid| }}                                                                                              
+                            {{#if m.isState}}                                                         
+                                    <span class="adjustment elite trait">{{localize (concat "CO.label.long." m.target)}}</span>
+                            {{/if}}
+                            {{/each}}
+                        {{/if}}
                     {{/each}}
                 </div>
             </div>


### PR DESCRIPTION
avant : affiche tout les modifier d'etat
apres :affiche uniquementr les modifier d'action "activé"