### PR TITLE
Fix taille minimale des fiches de personnage et d'objet

### DIFF
--- a/css/co.css
+++ b/css/co.css
@@ -2146,7 +2146,8 @@ strong,
   border-color: #ababab;
 }
 .co.sheet.actor.character {
-  min-width: 630px;
+  min-height: 480px;
+  min-width: 760px;
 }
 .co.sheet.actor.character .window-content {
   padding: 0;
@@ -3976,7 +3977,8 @@ strong,
   border-top: 1px solid #c9c7b8;
 }
 .co.sheet.actor.encounter {
-  min-width: 585px;
+  min-height: 480px;
+  min-width: 625px;
 }
 .co.sheet.actor.encounter .window-content {
   padding: 0;
@@ -5399,6 +5401,10 @@ strong,
   border: none;
   outline: 2px solid white;
   box-shadow: 3px 3px 5px gray;
+}
+.co.sheet.item {
+  min-height: 400px;
+  min-width: 400px;
 }
 .co.sheet.item .window-content {
   display: flex;

--- a/styles/components/actor/character/layout.less
+++ b/styles/components/actor/character/layout.less
@@ -9,7 +9,8 @@
 @import "styles/components/nav";
 &.sheet {
   &.actor.character {
-    min-width: 630px;
+    min-height: 480px;
+    min-width: 760px;
     .window-content {
       padding: 0;
       form.editable,

--- a/styles/components/actor/encounter/layout.less
+++ b/styles/components/actor/encounter/layout.less
@@ -9,7 +9,8 @@
 @import "styles/components/nav";
 &.sheet {
   &.actor.encounter {
-    min-width: 585px;
+    min-height: 480px;
+    min-width: 625px;
     .window-content {
       padding: 0;
       form.editable,

--- a/styles/components/item/layout.less
+++ b/styles/components/item/layout.less
@@ -3,6 +3,8 @@
 
 &.sheet {
   &.item {
+    min-height: 400px;
+    min-width: 400px;
     .window-content {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
Fixe la taille minimale des fiches de Personnage, Rencontre et d'Objet.

- La fiche de Personnage n'était pas limité en hauteur, j'ai mis une hauteur de 480px, pour la largeur, j'ai augmenté à 760px pour que les caract. INT et VOL ne soient pas cachées
- La fiche de Rencontre n'était pas limité en hauteur, j'ai mis une hauteur de 480px, pour la largeur, j'ai augmenté à 625px il y avait un "sursaut" en-dessous lors du changement de mode
- La fiche d'Objets n'était limité ni en hauteur, ni en largeur, j'ai mis une taille de 400px × 400px