### PR TITLE
Corrige le bug qui permet d'acheter des capacités de niveau supérieur…

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -52,7 +52,7 @@
       "cantUseAllDef": "Vous ne pouvez pas utiliser les deux types de défense simultanément",
       "healed": "{actorName} a été soigné de {amount} point(s) de vigueur",
       "damaged": "{actorName} perd {amount} point(s) de vigueur",
-      "warningNeedLearnedCapacities": "Vous devez apprendre les capacités des rang précédant avant d'apprendre celle-ci"
+      "warningNeedLearnedCapacities": "Vous devez apprendre les capacités des rangs précédents avant d'apprendre celle-ci"
     },
     "tooltip": {
       "formulaAttack": "Formule d'attaque (sans le dé)",

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -697,7 +697,7 @@ export default class COActor extends Actor {
     if (!capacity) return
 
     // Rang actuel de la voie
-    let path = await fromUuid(capacity.system.path)
+    let path = fromUuidSync(capacity.system.path)
     if (!path) return
     const currentRank = await path.system.computeRank()
 
@@ -708,13 +708,12 @@ export default class COActor extends Actor {
       // Les capacités de rang 6 à 8 sont réservées aux voies de prestige
       newRank = currentRank + 1
       if (this.system.attributes.level < SYSTEM.CAPACITY_MINIMUM_LEVEL[newRank]) return ui.notifications.warn(game.i18n.localize("CO.notif.warningLevelTooLow"))
-      // Pour apprendre une capacité il faut avoir appris les précédantes !
+      // RULE : Pour apprendre une capacité, il faut avoir appris les précédentes
       let pos = await path.system.getCapacityRank(capacity.uuid)
-      console.log("cette capacité a pour rang :", pos)
       for (let i = 0; i < pos; i++) {
         let c = path.system.capacities[i]
-        const current = await fromUuid(c)
-        if (current.system.learned === false) return ui.notifications.warn(game.i18n.localize("CO.notif.warningNeedLearnedCapacities"))
+        const current = fromUuidSync(c)
+        if (!current.system.learned) return ui.notifications.warn(game.i18n.localize("CO.notif.warningNeedLearnedCapacities"))
       }
     }
 

--- a/module/models/path.mjs
+++ b/module/models/path.mjs
@@ -42,21 +42,13 @@ export default class PathData extends ItemData {
     return max
   }
 
-  /** Renvoi la position de la capacité dans la voie
-   * @param {Uuid} capacityUuid de la capacité à chercher
-   * @returns {integer} Position dans la liste
+  /** Retourne la position d'une capacité dans la liste des capacités de la voie
+   * @param {string} capacityUuid L'UUID de la capacité recherchée
+   * @returns {number} La osition dans la liste ou 0 si la capacité n'est pas trouvée
    */
   async getCapacityRank(capacityUuid) {
-    console.log("je cherche ", capacityUuid)
-    let rankpos = 0
-    for (let i = 0; i < this.capacities.length; i++) {
-      console.log("je vois ", this.capacities[i])
-      if (this.capacities[i] === capacityUuid) {
-        rankpos = i
-        break
-      }
-    }
-    return rankpos
+    const rankpos = this.capacities.indexOf(capacityUuid)
+    return rankpos !== -1 ? rankpos : 0
   }
 
   /**


### PR DESCRIPTION
… sans prendre les précédantes

Lorsque l'on clic sur le bouton pour apprendre une capacité, j'ai ajouté : 
1. On vérifie à quel rang appartiens la capacité
2. Si dans els rang précédant on aune capacité non apprise on affiche un message d'erreur est on sort.
![image](https://github.com/user-attachments/assets/37dd93d9-3171-4a45-b0b1-1522e758a49f)
