### PR TITLE
fix l'issue 110 sur l'icone des actions de rencontres

### DIFF
--- a/templates/encounter/parts/encounter-main.hbs
+++ b/templates/encounter/parts/encounter-main.hbs
@@ -126,10 +126,10 @@
                                 {{else}}
                                     {{#if (or (eq action.type 'melee') (eq action.type 'ranged') (eq action.type 'magical'))}}
                                         <a class="item-control">
-                                            <i class="fas fa-dice-d20 green toggle-action" style="font-size:16px" data-tooltip="{{localize 'CO.label.long.attack'}}" data-action="activate" data-type="attack" data-source="{{action.source}}" data-indice="{{action.indice}}"></i>
+                                            <i class="{{action.iconFA}} green toggle-action" style="font-size:16px" data-tooltip="{{localize 'CO.label.long.attack'}}" data-action="activate" data-type="attack" data-source="{{action.source}}" data-indice="{{action.indice}}"></i>
                                         </a>
                                         <a class="item-control">
-                                            <i class="fas fa-dice-d20 green toggle-action" style="font-size:16px" data-tooltip="{{localize 'CO.label.long.damage'}}" data-action="activate" data-type="damage" data-source="{{action.source}}" data-indice="{{action.indice}}"></i>
+                                            <i class="fas fa-hand-back-fist green toggle-action" style="font-size:16px" data-tooltip="{{localize 'CO.label.long.damage'}}" data-action="activate" data-type="damage" data-source="{{action.source}}" data-indice="{{action.indice}}"></i>
                                         </a>
                                     {{else}}
                                         <a class="item-control">


### PR DESCRIPTION
corrige les icones utilisées pour les rencontre sur les attaque pour mettre idem fiche de perso