### PR TITLE
Fix#166

### DIFF
--- a/module/models/schemas/custom-effect.mjs
+++ b/module/models/schemas/custom-effect.mjs
@@ -30,6 +30,24 @@ export class CustomEffectData extends foundry.abstract.DataModel {
     }
   }
 
+  /**
+   * Génère un tooltip à partir d'un customEffect
+   * @returns {string} Renvoi un tooltip à afficher
+   */
+  get tooltip() {
+    let tip = `${game.i18n.localize("CO.ui.duration")} : ${this.duration} ${this.unit}<br />`
+    if (this.formula && this.formula !== "") tip += `${game.i18n.localize("CO.ui.dmg")} : ${this.formula}`
+    if (this.elementType && this.elementType !== "") tip += `${this.elementType}`
+    if (this.formula && this.formula !== "") tip += `<br />`
+    if (this.statuses && this.statuses.length > 0) tip += `${game.i18n.localize("CO.customEffect.status")} :${this.statuses.join(", ")}<br />`
+    if (this.modifiers && this.modifiers.length > 0) {
+      for (let i = 0; i < this.modifiers.length; i++) {
+        tip += ` ${game.i18n.localize(SYSTEM.MODIFIERS_SUBTYPE[this.modifiers[i].subtype].label)} ${game.i18n.localize(SYSTEM.MODIFIERS_TARGET[this.modifiers[i].target].label)} : ${this.modifiers[i].value}<br />`
+      }
+    }
+    return tip
+  }
+
   /** @override */
   prepareBaseData() {
     super.prepareBaseData()

--- a/templates/actors/parts/actor-effects.hbs
+++ b/templates/actors/parts/actor-effects.hbs
@@ -70,11 +70,11 @@
       <ol class="item-list">
         <!-- Liste des customEffects actuellement actifs -->
         {{#each currentEffects as |effect id|}}
-          {{!log (concat "Chroniques Oubliées | customEffect " id) effect}}
+          {{log (concat "Chroniques Oubliées | customEffect " id) effect}}
           <li class="item flexrow" data-item-uuid="{{effect.source}}" data-item-indice="{{id}}" data-item-type="customEffectData" draggable="false">
             <div class="item-name flexrow">
-              <!-- <a class="item-image item-edit" style="background-image: url('{{{actionImg}}}')"></a> -->
-              <h4>{{effect.name}}</h4>
+              <a class="item-image item-edit" style="background-image: url('icons/svg/aura.svg')"></a>
+              <h4 data-tooltip="{{effect.tooltip}}">{{effect.name}} : {{effect.duration}} {{effect.unit}}</h4>
               {{#if ../unlocked}}
                 <a class="item-control customEffect-delete" data-tooltip={{localize "CO.ui.remove"}} data-ce-Name={{effect.slug}}><i class="fas fa-trash"></i></a>
               {{/if}}


### PR DESCRIPTION
Modification de l'affichage des effets personnalisés : 

![image](https://github.com/user-attachments/assets/8d166453-72a4-4445-b625-12d5135fc05a)

Ajout de l'icone d'aura qui est celle par defaut des effets temporaires
Ajout d'un tooltip décrivant les effets.