### PR TITLE
Ajout du bouton pourutiliser un PC

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -546,6 +546,7 @@
         "content": "<p>Souhaitez-vous dépenser 1 point de récupération ?",
         "rollTitle": "Point de récupération"
       },
+      "spendLuckyPoint": "Utiliser un point de chance",
       "fastRest": {
         "title": "Récupération rapide",
         "content": "Souhaitez-vous effectuer une récupération rapide ?"

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1502,6 +1502,10 @@ export default class COActor extends Actor {
     const skillBonuses = this.getSkillBonuses(skillId) // Récupère un tableau d'objets avec {name, description, value}
     const hasSkillBonuses = skillBonuses.length > 0
 
+    // Gestion des points de chance
+    let hasLuckyPoints = false
+    if (this.system.resources?.fortune && this.system.resources.fortune.value > 0) hasLuckyPoints = true
+
     const dialogContext = {
       rollMode,
       rollModes: CONFIG.Dice.rollModes,
@@ -1524,6 +1528,7 @@ export default class COActor extends Actor {
       totalSkillBonuses: 0,
       targets,
       hasTargets: targets?.length > 0,
+      hasLuckyPoints,
     }
 
     let roll = await COSkillRoll.prompt(dialogContext, { withDialog: withDialog })
@@ -1704,6 +1709,10 @@ export default class COActor extends Actor {
       }
     }
 
+    // Gestion des points de chance
+    let hasLuckyPoints = false
+    if (this.system.resources?.fortune && this.system.resources.fortune.value > 0) hasLuckyPoints = true
+
     // Construction du message de chat
     if (chatFlavor === "") chatFlavor = `${item.name} ${actionName}`
 
@@ -1738,6 +1747,7 @@ export default class COActor extends Actor {
       tempDamage,
       canBeTempDamage,
       tactical,
+      hasLuckyPoints,
     }
 
     // Rolls contient le jet d'attaque et éventuellement le jet de dommages
@@ -2022,7 +2032,6 @@ export default class COActor extends Actor {
    *
    */
   async applyEffectOverTime() {
-    console.log(`applyEffectOverTime pour ${this.name}`)
     for (const effect of this.system.currentEffects) {
       // TODO Ici on devrait tenir compte du type d'energie (feu/glace etc) et d'eventuelle resistance/vulnerabilite à voir plus tard
       // Dé ou valeur fixe

--- a/module/documents/roll.mjs
+++ b/module/documents/roll.mjs
@@ -192,6 +192,7 @@ export class COSkillRoll extends CORoll {
       oppositeRoll: withDialog ? rollContext.difficulty?.includes("@oppose") : dialogContext.oppositeRoll.includes("@oppose"),
       oppositeTarget: dialogContext.targets?.length > 0 ? dialogContext.targets[0].uuid : null,
       oppositeValue: withDialog ? rollContext.difficulty : dialogContext.difficulty,
+      hasLuckyPoints: withDialog ? rollContext.hasLuckyPoints === "true" : dialogContext.hasLuckyPoints,
       useDifficulty: dialogContext.useDifficulty,
       showDifficulty: dialogContext.showDifficulty,
       difficulty: withDialog ? rollContext.difficulty : dialogContext.difficulty,
@@ -219,7 +220,6 @@ export class COSkillRoll extends CORoll {
 
   async _getChatCardData(flavor, isPrivate) {
     const rollResults = CORoll.analyseRollResult(this)
-    console.log("COSkillRoll _getChatCardData options", this.options)
     return {
       actor: this.options.actor,
       speaker: ChatMessage.getSpeaker({ actor: this.options.actor, scene: canvas.scene }),
@@ -232,6 +232,7 @@ export class COSkillRoll extends CORoll {
       isFumble: rollResults.isFumble,
       isSuccess: rollResults.isSuccess,
       isFailure: rollResults.isFailure,
+      hasLuckyPoints: this.options.hasLuckyPoints,
       total: isPrivate ? "?" : Math.round(this.total * 100) / 100,
       tooltip: isPrivate ? "" : await this.getTooltip(),
       user: game.user.id,
@@ -393,7 +394,6 @@ export class COAttackRoll extends CORoll {
 
       const roll = new this(formula, dialogContext.actor.getRollData())
       await roll.evaluate()
-
       const tooltip = await roll.getTooltip()
       roll.options = {
         actorId: dialogContext.actor.id,
@@ -410,6 +410,7 @@ export class COAttackRoll extends CORoll {
         oppositeRoll: withDialog ? rollContext.difficulty?.includes("@oppose") : dialogContext.oppositeRoll.includes("@oppose"),
         oppositeTarget: dialogContext.targets?.length > 0 ? dialogContext.targets[0].uuid : null,
         oppositeValue: withDialog ? rollContext.difficulty : dialogContext.difficulty,
+        hasLuckyPoints: dialogContext.hasLuckyPoints,
         useDifficulty: dialogContext.useDifficulty,
         showDifficulty: dialogContext.showDifficulty,
         difficulty: withDialog ? rollContext.difficulty : dialogContext.difficulty,
@@ -486,6 +487,7 @@ export class COAttackRoll extends CORoll {
       oppositeRoll: this.options.oppositeRoll,
       oppositeTarget: this.options.oppositeTarget,
       oppositeValue: this.options.difficulty,
+      hasLuckyPoints: this.options.hasLuckyPoints,
       difficulty: rollResults.difficulty,
       isCritical: rollResults.isCritical,
       isFumble: rollResults.isFumble,

--- a/module/socket.mjs
+++ b/module/socket.mjs
@@ -18,6 +18,10 @@ export function handleSocketEvent({ action = null, data = {} } = {}) {
       return CustomEffectData.handle(data)
     case "oppositeRoll":
       return _oppositeRoll(data)
+    case "_luckyRoll":
+      return _luckyRoll(data)
+    default:
+      return null
   }
 }
 
@@ -51,6 +55,25 @@ export async function _heal({ targets, healAmount, fromUserId }) {
 export async function _oppositeRoll({ userId, messageId, rolls, result } = {}) {
   console.log(`handleSocketEvent _oppositeRoll from ${userId} !`, messageId, rolls, result)
 
+  if (game.user.isGM) {
+    const message = game.messages.get(messageId)
+    await message.update({ rolls: rolls, "system.result": result })
+  }
+}
+
+/**
+ * Gère l'évènement socket "_luckyRoll", mettant à jour le message avec les infos du nouveau jet et du résultat.
+ * Marche aussi bien sur le skillRoll quele attackRoll
+ * @async
+ * @function _luckyRoll
+ * @param {Object} [params={}] The parameters for the function.
+ * @param {string} params.userId The ID of the user who triggered the event.
+ * @param {string} params.messageId The ID of the message to update.
+ * @param {Array} params.rolls The array of roll data to update the message with.
+ * @param {any} params.result The result to update in the message's system data.
+ * @returns {Promise<void>} Resolves when the message is successfully updated.
+ */
+export async function _luckyRoll({ userId, messageId, rolls, result } = {}) {
   if (game.user.isGM) {
     const message = game.messages.get(messageId)
     await message.update({ rolls: rolls, "system.result": result })

--- a/styles/global/chat.less
+++ b/styles/global/chat.less
@@ -58,6 +58,9 @@
       margin: 0;
       font-weight: bold;
     }
+    .lp-button {
+      text-align: center;
+    }
     > * {
       -webkit-user-select: text;
       -moz-user-select: text;
@@ -78,8 +81,7 @@
         justify-content: center;
         align-items: center;
       }
-    }
-  }
+    }    
   .card-buttons {
     margin: 5px 0;
     span {

--- a/templates/chat/attack-roll-card.hbs
+++ b/templates/chat/attack-roll-card.hbs
@@ -1,4 +1,4 @@
-{{log "Chroniques Oubliées | hbs | attack-roll-card" this}}
+{{!log "Chroniques Oubliées | hbs | attack-roll-card" this}}
 
 <div class="co chat-card roll-card attack-card" data-actor-id="{{speaker.actor}}">
   <header class="card-header flexcol">
@@ -42,6 +42,15 @@
         <span class="failure fumble"><i class="fas fa-skull-crossbones"></i>&nbsp;{{localize "CO.roll.fumble"}}.</span>
       {{/if}}
     {{/if}}
+    {{#if (eq type 'attack')}}
+      {{#if hasLuckyPoints}}
+        <div style="text-align: center;">
+          <a class="lp-button-attack">
+            <img class="" style="height: 27px;" src="icons/magic/control/buff-luck-fortune-green.webp" data-tooltip="{{localize 'CO.dialogs.spendLuckyPoint'}}" />
+          </a>
+        </div>
+      {{/if}}
+    {{/if}}   
 
     {{#if (eq type 'damage')}}
         <div class="damage-buttons">

--- a/templates/chat/skill-roll-card.hbs
+++ b/templates/chat/skill-roll-card.hbs
@@ -34,6 +34,13 @@
         <span class="failure fumble"><i class="fas fa-skull-crossbones"></i>&nbsp;{{localize "CO.roll.fumble"}}.</span>
       {{/if}}
     {{/if}}
+    {{#if hasLuckyPoints}}
+      <div style="text-align: center;">
+        <a class="lp-button-skill">
+          <img class="" style="height: 27px;" src="icons/magic/control/buff-luck-fortune-green.webp" data-tooltip="{{localize 'CO.dialogs.spendLuckyPoint'}}" />
+        </a>
+      </div>
+    {{/if}}
   </div>
 
   <footer class="card-footer">

--- a/templates/dialogs/skill-roll-dialog.hbs
+++ b/templates/dialogs/skill-roll-dialog.hbs
@@ -84,6 +84,7 @@
     <input class="field-value" id="critical" name="critical" type="text" value="{{critical}}" data-dtype="String" />
   </div>
 </div>
+<input class="field-value" id="hasLuckyPoints" name="hasLuckyPoints" type="hidden" value="{{hasLuckyPoints}}" data-dtype="Boolean
 
 {{#if hasTargets}}
   <hr />


### PR DESCRIPTION
Alors j'ai ajouté l'affichage d'un bouton pour utiliser un PC sur les fenetre de chat des skills et des attaques : 

![image](https://github.com/user-attachments/assets/d2e8b2b6-2b35-4a71-9481-2933188247d2)

![image](https://github.com/user-attachments/assets/8f454f78-381a-4aaf-aa2e-aa0ee038e996)

Si on a plus de PC le bouton ne s'affiche pas

Si on clic sur le bouton le message s'actualise avec le nouveau résultat et le bouton disparait (on ne peux pas utiliser 2 fois un PC sur une meme action)

![image](https://github.com/user-attachments/assets/bd56d2ed-0599-45a1-9457-162098a6ddf9)

si une attaque est du coup réussi et si l'option pour jeter automatiquemetn les dés de dommages est activé : 

![image](https://github.com/user-attachments/assets/159633df-761b-4d1d-a86b-5eb9357943cb)

ça va se lancer.

