### PR TITLE
Corrige l'usage de la condition action active

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -405,7 +405,8 @@
       "tacticalViolentAttack": "Attaque violente",
       "tacticalViolentAttackTooltip": "Attaque -7, DM +2d4°",
       "tacticalPreciseAttack": "Attaque précise",
-      "tacticalPreciseAttackTooltip": "Attaque -3, DM +1d4°"
+      "tacticalPreciseAttackTooltip": "Attaque -3, DM +1d4°",
+      "conditionLiee": "Indiquez le numéro de l'action liée (dans l'ordre d'apparition) qui doit être activé en commençant par 0,1..."
     },
     "properties": {
       "attack": "Attaque",
@@ -424,7 +425,8 @@
       "visible": "Visible",
       "activable": "Activable",
       "temporary": "Temporaire",
-      "noManaCost": "Sans coût en mana"
+      "noManaCost": "Sans coût en mana",
+      "noChargeCost": "Sans coût de charge"
     },
     "abilities": {
       "long": {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -745,7 +745,7 @@ export default class COActor extends Actor {
         }
       }
       // Si c'est une capacité avec une charge il faut la consommer
-      if (item.type === SYSTEM.ITEM_TYPE.capacity.id && item.system.hasFrequency && item.system.hasCharges) {
+      if (item.type === SYSTEM.ITEM_TYPE.capacity.id && item.system.hasFrequency && item.system.hasCharges && !item.system.actions[indice].properties.noChargeCost) {
         item.system.charges.current = Math.max(item.system.charges.current - 1, 0)
         await item.update({ "system.charges.current": item.system.charges.current })
         if (item.system.charges.current === 0) {
@@ -1163,7 +1163,7 @@ export default class COActor extends Actor {
     }
     // Update the array of capacities of the path with ids of created path
     await newPath[0].update({ "system.capacities": updatedCapacitiesUuids })
-
+    console.log("addPath", updatedCapacitiesUuids)
     return newPath[0].uuid
   }
 

--- a/module/models/character.mjs
+++ b/module/models/character.mjs
@@ -377,7 +377,7 @@ export default class CharacterData extends ActorData {
       let currentprestige = this.parent.paths.find((item) => item.system.subtype === SYSTEM.PATH_TYPES.prestige.id)
       let currentprestigePV = 0
       if (currentprestige && currentprestige.system.pvByLevel > 0) {
-        let nombreAppris = currentprestige.system.numberLearnedCapacities()
+        let nombreAppris = currentprestige.system.numberLearnedCapacities
         currentprestigePV = currentprestige.system.pvByLevel * nombreAppris
       }
 

--- a/module/models/path.mjs
+++ b/module/models/path.mjs
@@ -76,7 +76,9 @@ export default class PathData extends ItemData {
         capacities.push(item)
       }
     }
-    let learned = capacities.filter((c) => c.system.learned)
+    if (capacities.length === 0) return 0
+    console.log(capacities)
+    let learned = capacities.filter((c) => c.system?.learned)
     return learned.length
   }
 

--- a/module/models/schemas/action.mjs
+++ b/module/models/schemas/action.mjs
@@ -41,6 +41,7 @@ export class Action extends foundry.abstract.DataModel {
         enabled: new fields.BooleanField(),
         temporary: new fields.BooleanField(),
         noManaCost: new fields.BooleanField(),
+        noChargeCost: new fields.BooleanField(),
       }),
       conditions: new fields.ArrayField(new fields.EmbeddedDataField(Condition)),
       modifiers: new fields.ArrayField(new fields.EmbeddedDataField(Modifier)),

--- a/module/rules-engine.mjs
+++ b/module/rules-engine.mjs
@@ -36,7 +36,10 @@ export default class RulesEngine {
     {
       name: "isLinkedActionActivated",
       parameters: ["object", "item"],
-      expression: (object, item) => item.system.actions[object].properties.enabled,
+      expression: (object, item) => {
+        if (item.system.actions[object]) return item.system.actions[object].properties.enabled
+        else return false
+      },
     },
     {
       name: "isTagged",

--- a/templates/actors/character/character-sheet.hbs
+++ b/templates/actors/character/character-sheet.hbs
@@ -1,4 +1,4 @@
-{{!log "Chroniques Oubliées | character-sheet" this}}
+{{log "Chroniques Oubliées | character-sheet" this}}
 <form class="{{cssClass}} flexrow no-wrap" autocomplete="off">
     {{> "systems/co/templates/actors/character/parts/character-sidebar.hbs"}}
     <div class="main">

--- a/templates/items/parts/actions/action-partial.hbs
+++ b/templates/items/parts/actions/action-partial.hbs
@@ -60,6 +60,9 @@
                                 {{#if (and (eq ../itemType 'capacity') ../system.isSpell) }}
                                     <label class="checkbox"> <input type="checkbox" name="system.actions.{{idx}}.properties.noManaCost" {{checked action.properties.noManaCost}}> {{localize "CO.properties.noManaCost"}}</label>
                                 {{/if}}
+                                {{#if (and (eq ../itemType 'capacity') ../system.hasCharges) }}
+                                    <label class="checkbox"> <input type="checkbox" name="system.actions.{{idx}}.properties.noChargeCost" {{checked action.properties.noChargeCost}}> {{localize "CO.properties.noChargeCost"}}</label>
+                                {{/if}}
                             </div>
                         </div>
                         <br />

--- a/templates/items/parts/actions/conditions-partial.hbs
+++ b/templates/items/parts/actions/conditions-partial.hbs
@@ -14,7 +14,7 @@
                     </select>
                 </div>
                 {{#if (eq c.predicate "isLinkedActionActivated")}}
-                    <div class="form-fields flex1 center"><input name="system.actions.{{../idx}}.conditions.{{id}}.object" type="text" value="{{c.object}}" data-dtype="String"  /></div>                
+                    <div class="form-fields flex1 center"><input name="system.actions.{{../idx}}.conditions.{{id}}.object" type="text" value="{{c.object}}" data-dtype="String" data-tooltip="{{localize "CO.ui.conditionLiee"}}"  /></div>                
                 {{/if}}
                 <div class="form-fields flex0"><a class="condition-delete"><i class="fas fa-trash"></i></a></div>
             </div>


### PR DESCRIPTION
Corrige l'usage de la condition action liée entre autres chose voir fix 182.

Reste à regler dans un autre fixe : 

![image](https://github.com/user-attachments/assets/dcec3b52-b928-453f-8fbd-016bd248ded0)
si on clic sur l'action activable / temporaire qui a 1 charge, le rafraichissement de la fenetre fait que l'action est désactivée et plus de charge je vais faire un autre ticket pour ça