### PR TITLE
corrige un soucis de calcul de point xp

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -774,7 +774,7 @@ export default class COActor extends Actor {
     // Rang actuel de la voie
     let path = fromUuidSync(capacity.system.path)
     if (!path) return
-    const currentRank = path.system.rank
+    let currentRank = path.system.rank
 
     // Apprentissage d'une capacité
     if (state) {

--- a/module/models/character.mjs
+++ b/module/models/character.mjs
@@ -375,7 +375,7 @@ export default class CharacterData extends ActorData {
       let currentprestige = this.parent.paths.find((item) => item.system.subtype === SYSTEM.PATH_TYPES.prestige.id)
       let currentprestigePV = 0
       if (currentprestige && currentprestige.system.pvByLevel > 0) {
-        let nombreAppris = currentprestige.system.numberLearnedCapacities()
+        let nombreAppris = currentprestige.system.numberLearnedCapacities
         currentprestigePV = currentprestige.system.pvByLevel * nombreAppris
       }
 

--- a/templates/actors/parts/actor-effects.hbs
+++ b/templates/actors/parts/actor-effects.hbs
@@ -70,7 +70,7 @@
       <ol class="item-list">
         <!-- Liste des customEffects actuellement actifs -->
         {{#each currentEffects as |effect id|}}
-          {{log (concat "Chroniques Oubliées | customEffect " id) effect}}
+          {{!log (concat "Chroniques Oubliées | customEffect " id) effect}}
           <li class="item flexrow" data-item-uuid="{{effect.source}}" data-item-indice="{{id}}" data-item-type="customEffectData" draggable="false">
             <div class="item-name flexrow">
               <a class="item-image item-edit" style="background-image: url('icons/svg/aura.svg')"></a>

--- a/templates/actors/parts/actor-paths.hbs
+++ b/templates/actors/parts/actor-paths.hbs
@@ -1,4 +1,4 @@
-{{log "Chroniques Oubliées | hbs | actor-paths" this}}
+{{!log "Chroniques Oubliées | hbs | actor-paths" this}}
 
 {{#if (eq actor.type "character")}}
     {{formGroup systemFields.otherCapacitiesPointsSpent value=system.otherCapacitiesPointsSpent disabled=locked}}


### PR DESCRIPTION
Lorsqu'on glissait déposait une voie de prestige un message d'erreur affichait un probleme de nombred e points dépensé? C'est un effet secondaire en fait au fait que j'appeler un get avec les parenthese () alors qu'il les fallait pas : 

![image](https://github.com/user-attachments/assets/41aa6e0b-878f-4c4a-9b07-97f54aff7e54)

C'est corrigé et j'ai viré des log aussi