### PR TITLE
 retire le besoin d'etre en mode edition pour supprimer un effet temp…

### DIFF
--- a/templates/actors/shared/effects.hbs
+++ b/templates/actors/shared/effects.hbs
@@ -74,11 +74,9 @@
             {{log (concat "Chroniques Oubliées | customEffect " id) effect}}
             <li class="item flexrow" data-item-uuid="{{effect.source}}" data-item-indice="{{id}}" data-item-type="customEffectData" draggable="false">
                 <div class="item-name flexrow">
-                <a class="item-img" data-action="editItem" style="background-image: url('icons/svg/aura.svg')"></a>
-                <h4 data-tooltip="{{effect.tooltip}}">{{effect.name}} : {{effect.duration}} {{effect.unit}}</h4>
-                {{#if ../unlocked}}
+                    <a class="item-img" data-action="editItem" style="background-image: url('icons/svg/aura.svg')"></a>
+                    <h4 data-tooltip="{{effect.tooltip}}">{{effect.name}} : {{effect.duration}} {{effect.unit}}</h4>
                     <a class="item-control" data-action="deleteCustomEffect" data-ce-Name={{effect.slug}} data-tooltip={{localize "CO.ui.remove"}}><i class="fas fa-trash"></i></a>
-                {{/if}}
                 </div>
                 <div class="item-controls-2"></div>
             </li>


### PR DESCRIPTION
…oraire

A l'usage c'est chiant de passer en mode edition pour supprimer un effet temporaire, j'ai supprimé cette necessité. Autant oui il faut protéger le reste autant l'effet temporaire porte bien son nom :)
