### PR TITLE
Corrige les boutons d'actions temporaires

### DIFF
--- a/co.css
+++ b/co.css
@@ -295,9 +295,13 @@ co-toggle-switch[checked] thumb {
 }
 .co {
   --color-green: #44a12b;
+  --color-grey: #c2b9b7;
 }
 .co .enabled {
   color: var(--color-green);
+}
+.co .inactivated {
+  color: var(--color-grey);
 }
 .co.application ul,
 .co.application ol,

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -92,7 +92,7 @@ export default class COCharacterSheet extends COBaseActorSheet {
     const type = dataset.type
     const source = dataset.source
     const indice = dataset.indice
-
+    console.log("item-control", action, type, source, indice)
     let activation
     if (action === "activate") {
       activation = await this.document.activateAction({ state: true, source, indice, type, shiftKey })
@@ -325,5 +325,4 @@ export default class COCharacterSheet extends COBaseActorSheet {
     }
     return false
   }
-
 }

--- a/module/models/schemas/action.mjs
+++ b/module/models/schemas/action.mjs
@@ -366,7 +366,7 @@ export class Action extends foundry.abstract.DataModel {
         // Action temporaire désactivée -> bouton pour activer
         icons.push({
           icon: this.iconFA,
-          iconClass: "disabled toggle-action",
+          iconClass: "inactivated toggle-action",
           tooltip: "CO.ui.activate",
           actionType: "activate",
         })

--- a/styles/co.less
+++ b/styles/co.less
@@ -6,9 +6,14 @@
 
 .co {
   --color-green: #44a12b;
+  --color-grey: #c2b9b7;
 
   .enabled {
-    color: var(--color-green)
+    color: var(--color-green);
+  }
+
+  .inactivated {
+    color: var(--color-grey);
   }
 
   @import "./applications/_index.less";

--- a/templates/actors/character-main.hbs
+++ b/templates/actors/character-main.hbs
@@ -32,7 +32,7 @@
             <ol class="actions-container items-container">
                 <ol class="item-list">
                     {{#each visibleActivableActions as |action id|}}
-                        {{!log (concat "Chroniques Oubliées | action " id) action}}
+                        {{log (concat "Chroniques Oubliées | action " id) action}}
                             <li class="item flexrow action {{#if action.properties.temporary}}{{#unless action.properties.enabled}}deactivated{{/unless}}{{/if}}" draggable="true" data-item-uuid="{{action.source}}" data-indice="{{action.indice}}">
                                 <div class="item-name flexrow">
                                     <a class="item-img" data-action="editItem" style="background-image: url('{{{actionImg}}}')"></a>


### PR DESCRIPTION
une classe CSS etait mis sur les action temporaire non active : 

![462979114-a7248e8f-24cc-4218-ac3c-c0d524877d1b](https://github.com/user-attachments/assets/e0068c22-961e-4193-815d-1bb0a49a9529)

sauf que le disabled etait interpreté par le css de foundry 

![462980300-0edf6516-099c-48e3-8e15-6ac982004223](https://github.com/user-attachments/assets/2174ba5a-6e18-4b69-b0ec-5291a971c8b7)

et du coup les evenement souris n'etaient pas répercuté

j'ai remplacé par inactivated
![image](https://github.com/user-attachments/assets/e05312ee-6ece-4e98-994a-73fc0a7c2332)

Et j'ai mis du CSS gris pour monter que c'est une action temporaire non active : 

![image](https://github.com/user-attachments/assets/a1253a6f-6b0d-48a9-ad5f-de177e7900f8)


et là du coup ça marche : 
![image](https://github.com/user-attachments/assets/75d3e418-ee58-4911-9bb6-1221420dfffb)

FIx #232 
