### PR TITLE
corrige le message applyheal

### DIFF
--- a/module/models/character.mjs
+++ b/module/models/character.mjs
@@ -866,7 +866,7 @@ export default class CharacterData extends ActorData {
     newHp.value += roll.total
     newHp.value = Math.min(newHp.value, newHp.max)
 
-    new CoChat(this)
+    new CoChat(this.parent)
       .withTemplate("systems/co/templates/chat/healing-card.hbs")
       .withData({
         actorId: this.id,


### PR DESCRIPTION
Dasn la fonction 
  async _applyRecovery(rp, hp, formula, title) {
du fichier character.mjs
je créais un COChat avec new COChat(this) sauf qu'il fallait le créer avec un acteur pas un characterdata !
j'ai remplacé par new COChat(this.parent) et ça regle le soucis

Fix #243 