### PR TITLE
correction des messages chats

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -362,6 +362,7 @@
       "cantUseAllDef": "Vous ne pouvez pas utiliser les deux types de défense simultanément",
       "healed": "{actorName} a été soigné de {amount} point(s) de vigueur",
       "damaged": "{actorName} perd {amount} point(s) de vigueur",
+      "manaBurn": "{actorName} brûle {amount} point(s) de vigueur pour accomplir son sort {capacityName}",
       "warningNeedLearnedCapacities": "Vous devez apprendre les capacités des rangs précédents avant d'apprendre celle-ci",
       "consume": "{actorName} a consommé un(e) {itemName}"
     },

--- a/module/applications/sheets/character-sheet.mjs
+++ b/module/applications/sheets/character-sheet.mjs
@@ -91,7 +91,6 @@ export default class COCharacterSheet extends COBaseActorSheet {
     const type = dataset.type
     const source = dataset.source
     const indice = dataset.indice
-    console.log("item-control", action, type, source, indice)
     let activation
     if (action === "activate") {
       activation = await this.document.activateAction({ state: true, source, indice, type, shiftKey })

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -12,6 +12,7 @@ import * as PROFILE from "./profile.mjs"
 import * as EFFECTS from "./effects.mjs"
 import * as COMBAT from "./combat.mjs"
 import * as CHAT from "./chat.mjs"
+import * as TEMPLATE from "./template.mjs"
 
 export const ASCII = `
    ******    *******  
@@ -131,5 +132,6 @@ export const SYSTEM = {
   RESOURCES: CHARACTER.RESOURCES,
   SIZES,
   STATUS_EFFECT: EFFECTS.CUSTOM_STATUS_EFFECT,
+  TEMPLATE: TEMPLATE.TEMPLATE,
   TOKEN_SIZE,
 }

--- a/module/config/template.mjs
+++ b/module/config/template.mjs
@@ -1,0 +1,4 @@
+// Template utilisés sur COFv2
+export const TEMPLATE = {
+  MESSAGE: "systems/co/templates/chat/message-card.hbs",
+}

--- a/module/models/encounter.mjs
+++ b/module/models/encounter.mjs
@@ -136,7 +136,7 @@ export default class EncounterData extends ActorData {
     this._prepareCombat()
   }
 
-  _prepareCombat() {
+  async _prepareCombat() {
     for (const [key, skill] of Object.entries(this.combat)) {
       // Somme du bonus de la feuille et du bonus des effets
       const bonuses = Object.values(skill.bonuses).reduce((prev, curr) => prev + curr)
@@ -166,6 +166,11 @@ export default class EncounterData extends ActorData {
           this.combat.crit.value = this.combat.crit.base
         }
       }
+    }
+
+    // Si hp à 0 il est mort
+    if (this.attributes.hp.value === 0 && !this.parent.statuses.has("dead")) {
+      await this.parent.toggleStatusEffect("dead", { active: true })
     }
 
     this.magic = this.abilities.vol.value + (this.attributes.nc === 0.5 ? 1 : this.attributes.nc)

--- a/templates/actors/character-biography.hbs
+++ b/templates/actors/character-biography.hbs
@@ -1,5 +1,5 @@
 {{!-- Character Biography Tab Template --}}
-{{log "Chroniques Oubliées | biography" this}}
+{{!log "Chroniques Oubliées | biography" this}}
 <section class="tab standard-form biography{{#if tabs.biography.active}} active{{/if}}" data-group="primary" data-tab="biography">
 
     <div class="features section-container">

--- a/templates/actors/character-header.hbs
+++ b/templates/actors/character-header.hbs
@@ -1,4 +1,4 @@
-{{log "Chroniques Oubliées | Character header" this}}
+{{!log "Chroniques Oubliées | Character header" this}}
 <header class="sheet-header">
   <div class="image-container">
     <img class="actor-img" src="{{actor.img}}" data-action="editImage" data-tooltip="{{actor.name}}" />
@@ -42,7 +42,7 @@
           {{localize (concat "CO.abilities.short." id)}}
           {{#if ability.superior}}<i class="fas fa-asterisk"></i>{{/if}}
         </div>
-        <a class="ability-mod" data-action="roll"data-roll-type="skillcheck" data-roll-target="{{id}}" data-tooltip="{{ability.tooltipValue}}">
+        <a class="ability-mod" data-action="roll" data-roll-type="skillcheck" data-roll-target="{{id}}" data-tooltip="{{ability.tooltipValue}}">
           {{numberFormat ability.value decimals=0 sign=true}}
         </a>
       </li>

--- a/templates/actors/character-inventory.hbs
+++ b/templates/actors/character-inventory.hbs
@@ -1,5 +1,5 @@
 {{!-- Character Inventory Tab Template --}}
-{{log "Chroniques Oubliées | Character inventory" this}}
+{{!log "Chroniques Oubliées | Character inventory" this}}
 <section class="tab standard-form inventory{{#if tabs.inventory.active}} active{{/if}}" data-group="primary" data-tab="inventory">
 
 <!-- Currencies -->
@@ -18,7 +18,7 @@
 </ol>
 
 {{#each inventory as |items category|}}
-  {{log "Chroniques Oubliées | inventory group" items category}}
+  {{!log "Chroniques Oubliées | inventory group" items category}}
   <ol class="items-container" data-tab="inventory" data-category="{{category}}">
     <li class="items-container-header flexrow">
       <h4 class="item-name flexrow">

--- a/templates/actors/character-main.hbs
+++ b/templates/actors/character-main.hbs
@@ -1,5 +1,5 @@
 {{!-- Character Main Tab Template --}}
-{{log "Chroniques Oubliées | Character main" this}}
+{{!log "Chroniques Oubliées | Character main" this}}
 <section class="tab standard-form main{{#if tabs.main.active}} active{{/if}}" data-group="primary" data-tab="main">
     <div class="section-container actions">
         <div class="section-header">
@@ -32,7 +32,7 @@
             <ol class="actions-container items-container">
                 <ol class="item-list">
                     {{#each visibleActivableActions as |action id|}}
-                        {{log (concat "Chroniques Oubliées | action " id) action}}
+                        {{!log (concat "Chroniques Oubliées | action " id) action}}
                             <li class="item flexrow action {{#if action.properties.temporary}}{{#unless action.properties.enabled}}deactivated{{/unless}}{{/if}}" draggable="true" data-item-uuid="{{action.source}}" data-indice="{{action.indice}}">
                                 <div class="item-name flexrow">
                                     <a class="item-img" data-action="editItem" style="background-image: url('{{{actionImg}}}')"></a>

--- a/templates/actors/character-sidebar.hbs
+++ b/templates/actors/character-sidebar.hbs
@@ -1,4 +1,4 @@
-{{log "Chroniques Oubliées | Character sidebar" this}}
+{{!log "Chroniques Oubliées | Character sidebar" this}}
 <div class="sheet-sidebar">
   <div class="scrollable">
     <!-- MELEE -->

--- a/templates/actors/shared/effects.hbs
+++ b/templates/actors/shared/effects.hbs
@@ -1,5 +1,5 @@
 {{!-- Character Effects Tab Template --}}
-{{log "Chroniques Oubliées | effects" this}}
+{{!log "Chroniques Oubliées | effects" this}}
 <section class="tab standard-form effects{{#if tabs.effects.active}} active{{/if}}" data-group="primary" data-tab="effects">
     <div class="section-body-no-flex">
         <!-- ACTIONS -->
@@ -71,7 +71,7 @@
         <ol class="item-list">
             <!-- Liste des customEffects actuellement actifs -->
             {{#each currentEffects as |effect id|}}
-            {{log (concat "Chroniques Oubliées | customEffect " id) effect}}
+            {{!log (concat "Chroniques Oubliées | customEffect " id) effect}}
             <li class="item flexrow" data-item-uuid="{{effect.source}}" data-item-indice="{{id}}" data-item-type="customEffectData" draggable="false">
                 <div class="item-name flexrow">
                     <a class="item-img" data-action="editItem" style="background-image: url('icons/svg/aura.svg')"></a>

--- a/templates/actors/shared/paths.hbs
+++ b/templates/actors/shared/paths.hbs
@@ -1,5 +1,5 @@
 {{!-- Character Paths Tab Template --}}
-{{log "Chroniques Oubliées | paths" this}}
+{{!log "Chroniques Oubliées | paths" this}}
 <section class="tab standard-form paths{{#if tabs.paths.active}} active{{/if}}" data-group="primary" data-tab="paths">
 
 

--- a/templates/chat/message-card.hbs
+++ b/templates/chat/message-card.hbs
@@ -1,0 +1,4 @@
+<div class="message-card" data-actor-id="{{actorId}}" data-item-id="{{id}}" data-item-uuid="{{uuid}}">
+  <hr />
+  <div><p>{{message}}</p></div>
+</div>


### PR DESCRIPTION
Plusieurs modifs : 

- Ajout d'un template chat pour les messages
- Ajout d'un messsage pour la brulure de mana
- Modification des message de degat et soin car je mettais un content type string là ou le Chat attendait un template ça provoquait une erreur dans la console meme si ça s'affichait
- suppression de multiple log qui rendaient compliqué la lecture de la console
- les encounter ne mettaient pas le statut "dead" lorsqu'ils arrivaient à 0 pv

FIx #160