### PR TITLE
Correction des sort qui ne depensais pas de mana et des icones d'actions

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -710,7 +710,6 @@ export default class COActor extends Actor {
       let resolvers = Object.values(action.resolvers).map((r) => foundry.utils.deepClone(r))
       // Résolution de tous les resolvers avant de continuer
       results = await Promise.all(resolvers.map((resolver) => resolver.resolve(this, item, action, type)))
-
       // Si tous les resolvers ont réussi
       allResolversTrue = results.length > 0 && results.every((result) => result === true)
 
@@ -731,13 +730,11 @@ export default class COActor extends Actor {
         }
       }
     }
-
     // Pas de resolvers ou tous les resolvers ont été résolus avec succès
     if (results.length === 0 || allResolversTrue) {
       // Si c'est un sort et qu'on l'active, il faut consommer les Points de Mana
       if (!item.system.actions[indice].properties.noManaCost && state && item.type === SYSTEM.ITEM_TYPE.capacity.id && item.system.isSpell) {
         const spellManaCost = item.system.getManaCost() + manaCostFromArmor - (manaConcentration ? 2 : 0)
-
         if (spellManaCost > 0) {
           const newMana = Math.max(this.system.resources.mana.value - spellManaCost, 0)
           await this.update({ "system.resources.mana.value": newMana })

--- a/module/models/schemas/action.mjs
+++ b/module/models/schemas/action.mjs
@@ -406,12 +406,43 @@ export class Action extends foundry.abstract.DataModel {
         }
       }
       // Action de soin
-      else if (this.type === "heal") {
+      else if (this.type === SYSTEM.ACTION_TYPES.heal.id) {
+        icons.push({
+          icon: `fa-solid fa-hand-holding-medical`,
+          iconClass: `${this.iconColor} toggle-action`,
+          tooltip: "CO.ui.use",
+          actionType: "activate",
+          type: SYSTEM.RESOLVER_TYPE.heal.id,
+        })
+      }
+      // Action de buff/debuff
+      else if (this.type === SYSTEM.ACTION_TYPES.buff.id) {
+        icons.push({
+          icon: `fa-solid fa-thumbs-up`,
+          iconClass: `${this.iconColor} toggle-action`,
+          tooltip: "CO.ui.use",
+          actionType: "activate",
+          type: SYSTEM.RESOLVER_TYPE.buffDebuff.id,
+        })
+      }
+      // Action de buff/debuff
+      else if (this.type === SYSTEM.ACTION_TYPES.debuff.id) {
+        icons.push({
+          icon: `fa-solid fa-thumbs-down`,
+          iconClass: `${this.iconColor} toggle-action`,
+          tooltip: "CO.ui.use",
+          actionType: "activate",
+          type: SYSTEM.RESOLVER_TYPE.buffDebuff.id,
+        })
+      }
+      // Action de consommable
+      else if (this.type === SYSTEM.ACTION_TYPES.consumable.id) {
         icons.push({
           icon: `fa-solid fa-flask-round-potion`,
           iconClass: `${this.iconColor} toggle-action`,
           tooltip: "CO.ui.use",
           actionType: "activate",
+          type: SYSTEM.RESOLVER_TYPE.consumable.id,
         })
       }
       // Autres types d'action

--- a/module/models/schemas/resolver.mjs
+++ b/module/models/schemas/resolver.mjs
@@ -54,15 +54,15 @@ export class Resolver extends foundry.abstract.DataModel {
 
   async resolve(actor, item, action, type) {
     switch (this.type) {
-      case "attack":
+      case SYSTEM.RESOLVER_TYPE.attack.id:
         return await this.attack(actor, item, action, type)
-      case "auto":
+      case SYSTEM.RESOLVER_TYPE.auto.id:
         return await this.auto(actor, item, action)
-      case "heal":
+      case SYSTEM.RESOLVER_TYPE.heal.id:
         return await this.heal(actor, item, action)
-      case "consumable":
+      case SYSTEM.RESOLVER_TYPE.consumable.id:
         return await this.consume(actor, item, action)
-      case "buffDebuff":
+      case SYSTEM.RESOLVER_TYPE.buffDebuff.id:
         return await this.buffDebuff(actor, item, action)
       default:
         return false
@@ -229,7 +229,7 @@ export class Resolver extends foundry.abstract.DataModel {
    * @param {Actor} actor L'acteur sur lequel l'effet sera appliqué.
    * @param {Item} item L'objet déclenchant l'effet supplémentaire.
    * @param {Object} action L'action contenant les modificateurs et autres données pertinentes.
-   * @returns {Promise<void>} Résout lorsque l'effet a été appliqué avec succès.
+   * @returns {Promise<bool>} Résout lorsque l'effet a été appliqué avec succès.
    *
    *
    * @description
@@ -254,7 +254,7 @@ export class Resolver extends foundry.abstract.DataModel {
     if (!game.combat || !game.combat.started) {
       // FIXME : Debug pour l'instant, à supprimer
       ui.notifications.warn("Pas de combat en cours ou combat non démarré !")
-      return
+      return false
     }
 
     const ce = await this._createCustomEffect(actor, item, action)
@@ -277,6 +277,7 @@ export class Resolver extends foundry.abstract.DataModel {
         })
       }
     }
+    return true
   }
 
   async _createCustomEffect(actor, item, action) {

--- a/templates/actors/character-main.hbs
+++ b/templates/actors/character-main.hbs
@@ -44,7 +44,7 @@
                                             <i class="{{icon.icon}} {{icon.iconClass}}"    
                                             data-action="toggleAction"                                         
                                             data-action-type="{{icon.actionType}}" 
-                                            {{#if icon.type}}data-type="{{icon.type}}"{{/if}} 
+                                            {{#if icon.type}}data-type="{{icon.type}}"{{/if}}
                                             data-source="{{action.source}}"
                                             data-indice="{{action.indice}}"
                                             data-tooltip="{{localize icon.tooltip}}" 


### PR DESCRIPTION
Alors la fonction getActionIcons() { n'etait pas complète et ne tenais pas compte de certains type d'action et type de resolver y compris au niveau des icone. J'en ai profité pour placer les variable depuis le "SYSTEM" et non pas en dure.
Ensuite dnas le resolver la fonction pour résoudre les buff/debuff ne retournais que du void et non pas un bool donc dans la gestino des action dans l'actor le ResolverAll machin n'etais pas sur true donc on depensais pas les MP....

