### PR TITLE
Corrige un soucis d'application des effet sur attaque opposée

### DIFF
--- a/module/applications/sheets/attack-sheet.mjs
+++ b/module/applications/sheets/attack-sheet.mjs
@@ -44,8 +44,6 @@ export default class CoAttackSheet extends CoBaseItemSheet {
 
     context.resolverSystemFields = this.document.system.schema.fields.actions.element.fields.resolvers.element.fields
     context.choiceAttackType = SYSTEM.ATTACK_TYPE
-
-    console.log(`CoAttackSheet - context`, context)
     return context
   }
 

--- a/module/applications/sheets/capacity-sheet.mjs
+++ b/module/applications/sheets/capacity-sheet.mjs
@@ -45,8 +45,6 @@ export default class CoCapacitySheet extends CoBaseItemSheet {
     const context = await super._prepareContext()
 
     context.resolverSystemFields = this.document.system.schema.fields.actions.element.fields.resolvers.element.fields
-
-    console.log(`CoCapacitySheet - context`, context)
     return context
   }
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1812,6 +1812,7 @@ export default class COActor extends Actor {
 
     // Jet d'attaque
     if (type === "attack") {
+      console.log("jet de type attaque avant message : ", customEffect, additionalEffect)
       // Affichage du jet d'attaque
       await rolls[0].toMessage(
         {

--- a/module/hooks.mjs
+++ b/module/hooks.mjs
@@ -54,7 +54,6 @@ export default function registerHooks() {
 
     // Clic sur les boutons d'action
     html.find(".toggle-action").click(async (event) => {
-      console.log("Hook toggle-action", event)
       const shiftKey = !!event.shiftKey
       const dataset = event.currentTarget.dataset
 
@@ -176,10 +175,8 @@ export default function registerHooks() {
       const dataset = event.currentTarget.dataset
       const oppositeValue = dataset.oppositeValue
       const oppositeTarget = dataset.oppositeTarget
-      console.log("Jet opposé", oppositeValue, oppositeTarget)
 
       const messageId = event.currentTarget.closest(".message").dataset.messageId
-      console.log("Message ID", messageId)
 
       const targetActor = await fromUuid(oppositeTarget)
       const value = Utils.evaluateOppositeFormula(oppositeValue, targetActor)
@@ -187,7 +184,6 @@ export default function registerHooks() {
       const formula = value ? `1d20 + ${value}` : `1d20`
       const roll = await new Roll(formula).roll()
       const difficulty = roll.total
-
       const message = game.messages.get(messageId)
 
       let rolls = message.rolls

--- a/module/models/action-message.mjs
+++ b/module/models/action-message.mjs
@@ -13,6 +13,17 @@ export default class ActionMessageData extends BaseMessageData {
       result: new fields.ObjectField(),
       linkedRoll: new fields.ObjectField(),
       customEffect: new fields.EmbeddedDataField(CustomEffectData),
+      additionalEffect: new fields.SchemaField({
+        active: new fields.BooleanField({ initial: false }),
+        applyOn: new fields.StringField({ required: true, choices: SYSTEM.RESOLVER_RESULT, initial: SYSTEM.RESOLVER_RESULT.success.id }),
+        successThreshold: new fields.NumberField({ integer: true, positive: true }),
+        statuses: new fields.SetField(new fields.StringField({ required: true, blank: true, choices: SYSTEM.RESOLVER_ADDITIONAL_EFFECT_STATUS })),
+        duration: new fields.StringField({ required: true, nullable: false, initial: "0" }),
+        unit: new fields.StringField({ required: true, choices: SYSTEM.COMBAT_UNITE, initial: "round" }),
+        formula: new fields.StringField({ required: false }),
+        formulaType: new fields.StringField({ required: false, choices: SYSTEM.RESOLVER_FORMULA_TYPE }),
+        elementType: new fields.StringField({ required: false }),
+      }),
       applyOn: new fields.StringField({ required: false }),
     })
   }

--- a/module/models/schemas/resolver.mjs
+++ b/module/models/schemas/resolver.mjs
@@ -110,9 +110,9 @@ export class Resolver extends foundry.abstract.DataModel {
       bonusDice: this.bonusDiceAdd ? 1 : 0,
       malusDice: this.malusDiceAdd ? 1 : 0,
       customEffect,
-      applyOn: this.additionalEffect.applyOn,
+      additionalEffect: this.additionalEffect,
     })
-
+    console.log("resolver - customEffet - attack result", customEffect, this.additionalEffect, result)
     if (result === null) return false
 
     // Gestion des effets supplémentaires


### PR DESCRIPTION
Sur les attaque magique opposé (saper les forces) les malus ne s'appliquaient pas aux adversaire parce qu'on attendait une variable "additionalEffect" qui etait undefined au final du coup j'ai du remonter en amont et modifier les passage de variable en parametre pour que ça marche
reste a resoudre comment appliquer les effets sur des encounter mais ce sera dans un autre fixe

Fix #233 