### PR TITLE
Corrige un margin sur firefox uniquement

### DIFF
--- a/co.css
+++ b/co.css
@@ -2388,6 +2388,11 @@ co-toggle-switch[checked] thumb {
 .co.application.sheet.actor .window-content .sheet-sidebar .scrollable .sidebar-section .state-modifier {
   color: var(--color-textLight);
 }
+@-moz-document url-prefix('') {
+  .co.application.sheet.actor .window-content .sheet-sidebar .scrollable {
+    margin-right: 2px;
+  }
+}
 .co.application.sheet.actor .window-content .abilities {
   box-sizing: border-box;
   border: 2px solid var(--color-abilities);

--- a/styles/applications/sheets/actors/common-sidebar.less
+++ b/styles/applications/sheets/actors/common-sidebar.less
@@ -217,4 +217,9 @@
       }
     }
   }
+  @-moz-document url-prefix('') {
+    .scrollable {
+      margin-right: 2px;
+    }
+  }
 }


### PR DESCRIPTION
corrige l'issue 229 sur firefox : 

<img width="283" height="159" alt="image" src="https://github.com/user-attachments/assets/7fdee293-6902-46cf-bd9f-cc857a7b1928" />

deviens : 
<img width="285" height="152" alt="image" src="https://github.com/user-attachments/assets/b38b839a-c4b2-40f9-96c9-8de1837ff2fe" />

Fix #229
