### PR TITLE
gere les bonus/malus sur contact/distance/magique des encounter

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1500,7 +1500,7 @@ export default class COActor extends Actor {
      * A hook event that fires before the roll is made.
      * @function co.preRollSkill
      * @memberof hookEvents
-     * @param {String} skillId          skillId for the roll.
+     * @param {string} skillId          skillId for the roll.
      * @param {Object} options          Options for the roll.
      * @returns {boolean}               Explicitly return `false` to prevent roll to be made.
      */
@@ -1632,7 +1632,7 @@ export default class COActor extends Actor {
      * A hook event that fires after the roll is made.
      * @function co.postRollSkill
      * @memberof hookEvents
-     * @param {String} skillId         skillId for the roll.
+     * @param {string} skillId         skillId for the roll.
      * @param {Object} options         Options for the roll.
      * @param {Roll} roll              The roll made.
      * @returns {boolean}              Explicitly return `false` to prevent roll to be made.
@@ -1645,7 +1645,7 @@ export default class COActor extends Actor {
      * A hook event that fires before the results of the roll.
      * @function co.resultRollSkill
      * @memberof hookEvents
-     * @param {String} skillId          skillId for the roll.
+     * @param {string} skillId          skillId for the roll.
      * @param {Object} options          Options for the roll.
      * @param {Object} result           The analysed result of the roll.
      * @returns {boolean}               Explicitly return `false` to prevent roll to be made.
@@ -1660,6 +1660,12 @@ export default class COActor extends Actor {
     await roll.toMessage({ style: CONST.CHAT_MESSAGE_STYLES.OTHER, type: "skill", system: { targets: targetsUuid, result: result }, speaker }, { rollMode: roll.options.rollMode })
   }
 
+  /**
+   * Lance un jet d'attaque
+   * @param {COItem} item : la source de l'action
+   * @param {*} options : Ensemble d'elements permettant les calculs
+   * @returns {*} Renvoi un tableau de résultat de jet de dé
+   */
   async rollAttack(
     item,
     {
@@ -1869,6 +1875,22 @@ export default class COActor extends Actor {
 
     // Construction du message de chat
     if (chatFlavor === "") chatFlavor = `${item.name} ${actionName}`
+
+    // Si l'actor est un encounter je dois prendre en comtpe en skillBonus ou skillMalus les modifiers qui lui sont apportés
+    if (this.type === "encounter") {
+      if (item.type === "attack") {
+        if (item.system.isContact) {
+          if (this.system.combat.melee.value > 0) skillBonus += this.system.combat.melee.value
+          else if (this.system.combat.melee.value < 0) skillMalus += this.system.combat.melee.value
+        } else if (item.system.isRanged) {
+          if (this.system.combat.ranged.value > 0) skillBonus += this.system.combat.ranged.value
+          else if (this.system.combat.ranged.value < 0) skillMalus += this.system.combat.ranged.value
+        } else if (item.system.isMagic) {
+          if (this.system.combat.magic.value > 0) skillBonus += this.system.combat.magic.value
+          else if (this.system.combat.magic.value < 0) skillMalus += this.system.combat.magic.value
+        }
+      }
+    }
 
     const dialogContext = {
       rollMode,

--- a/module/models/encounter.mjs
+++ b/module/models/encounter.mjs
@@ -49,6 +49,9 @@ export default class EncounterData extends ActorData {
       def: new fields.EmbeddedDataField(BaseValue),
       dr: new fields.EmbeddedDataField(BaseValue),
       crit: new fields.EmbeddedDataField(BaseValue),
+      melee: new fields.EmbeddedDataField(BaseValue), // Va servir à stocker les modifiers
+      ranged: new fields.EmbeddedDataField(BaseValue), // Va servir à stocker les modifiers
+      magic: new fields.EmbeddedDataField(BaseValue), // Va servir à stocker les modifiers
     })
 
     schema.magic = new fields.NumberField({ ...requiredInteger, initial: 0 })
@@ -178,15 +181,7 @@ export default class EncounterData extends ActorData {
       // Somme du bonus de la feuille et du bonus des effets
       const bonuses = Object.values(skill.bonuses).reduce((prev, curr) => prev + curr)
       const combatModifiersBonus = this.computeTotalModifiersByTarget(this.combatModifiers, key)
-      if (key === SYSTEM.COMBAT.init.id) {
-        skill.value = skill.base + bonuses + combatModifiersBonus.total
-      }
-
-      if (key === SYSTEM.COMBAT.def.id) {
-        skill.value = skill.base + bonuses + combatModifiersBonus.total
-      }
-
-      if (key === SYSTEM.COMBAT.dr.id) {
+      if (key !== SYSTEM.COMBAT.crit.id) {
         skill.value = skill.base + bonuses + combatModifiersBonus.total
       }
 


### PR DESCRIPTION
Fix #250 

ajout des melee, ranged, magic dans les variables de combat des encounter pour gérer les modifiers qui leurs sont appliqués
Mise en place de conditions dans le rollAttack pour gérer les skillBonus/skillMalus avec ces valeurs

<img width="1265" height="871" alt="image" src="https://github.com/user-attachments/assets/292ef5b7-799f-43bb-a3e7-9e38469c3423" />

