### PR TITLE
Prise en compte de bonus/malus et modifiers dans le rollskill encounter

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1948,7 +1948,6 @@ export default class COActor extends Actor {
 
     // Jet d'attaque
     if (type === "attack") {
-      console.log("jet de type attaque avant message : ", customEffect, additionalEffect)
       // Affichage du jet d'attaque
       await rolls[0].toMessage(
         {

--- a/module/models/actor.mjs
+++ b/module/models/actor.mjs
@@ -1,4 +1,5 @@
 import { AbilityValue } from "./schemas/ability-value.mjs"
+import { CustomEffectData } from "./schemas/custom-effect.mjs"
 
 export default class ActorData extends foundry.abstract.TypeDataModel {
   static defineSchema() {
@@ -12,7 +13,7 @@ export default class ActorData extends foundry.abstract.TypeDataModel {
         return obj
       }, {}),
     )
-
+    schema.currentEffects = new fields.ArrayField(new fields.EmbeddedDataField(CustomEffectData))
     return schema
   }
 

--- a/module/models/character.mjs
+++ b/module/models/character.mjs
@@ -3,7 +3,7 @@ import { BaseValue } from "./schemas/base-value.mjs"
 import ActorData from "./actor.mjs"
 import Utils from "../utils.mjs"
 import CoChat from "../chat.mjs"
-import { CustomEffectData } from "./schemas/custom-effect.mjs"
+
 import DefaultConfiguration from "../config/configuration.mjs"
 import { Modifier } from "./schemas/modifier.mjs"
 export default class CharacterData extends ActorData {
@@ -131,7 +131,6 @@ export default class CharacterData extends ActorData {
       }, {}),
     )
 
-    schema.currentEffects = new fields.ArrayField(new fields.EmbeddedDataField(CustomEffectData))
     // Permet de stocker l'ancienne distance de visibilité avant de passer en vision nocturne ou autre, de façon à revenir dessus si on l'enleve (cf fix#141)
     schema.oldDistanceView = new fields.NumberField({ required: true, nullable: false, initial: 0, integer: true, min: 0 })
 


### PR DESCRIPTION
Fix #285 

Corrige le point 1 : non prise en compte de dé bonus/malus (lié entre autre à ActorData qui a depuis peu certaines fonction appelant d'autre fonction qui était dans des sous classe mais pas dnas la clase parent....
Corrige la prise en compte des modifiers d'ability dans les encounter.

<img width="1216" height="365" alt="image" src="https://github.com/user-attachments/assets/94a1e476-71b0-4da8-ab14-61b3129694b8" />

<img width="1249" height="346" alt="image" src="https://github.com/user-attachments/assets/86ff653f-da68-4f2b-9729-f2d1b820ecdf" />
