### PR TITLE
Placement de Description comme onglet de base

### DIFF
--- a/module/applications/sheets/attack-sheet.mjs
+++ b/module/applications/sheets/attack-sheet.mjs
@@ -31,7 +31,7 @@ export default class CoAttackSheet extends CoBaseItemSheet {
   static TABS = {
     primary: {
       tabs: [{ id: "description" }, { id: "details" }, { id: "actions" }],
-      initial: "details",
+      initial: "description",
       labelPrefix: "CO.sheet.tabs.attack",
     },
   }

--- a/module/applications/sheets/capacity-sheet.mjs
+++ b/module/applications/sheets/capacity-sheet.mjs
@@ -33,7 +33,7 @@ export default class CoCapacitySheet extends CoBaseItemSheet {
   static TABS = {
     primary: {
       tabs: [{ id: "description" }, { id: "details" }, { id: "actions" }],
-      initial: "details",
+      initial: "description",
       labelPrefix: "CO.sheet.tabs.capacity",
     },
   }

--- a/module/applications/sheets/equipment-sheet.mjs
+++ b/module/applications/sheets/equipment-sheet.mjs
@@ -33,7 +33,7 @@ export default class CoEquipmentSheet extends CoBaseItemSheet {
   static TABS = {
     primary: {
       tabs: [{ id: "description" }, { id: "details" }, { id: "actions" }],
-      initial: "details",
+      initial: "description",
       labelPrefix: "CO.sheet.tabs.equipment",
     },
   }

--- a/module/applications/sheets/feature-sheet.mjs
+++ b/module/applications/sheets/feature-sheet.mjs
@@ -22,7 +22,7 @@ export default class CoFeatureSheet extends CoBaseItemSheet {
   static TABS = {
     primary: {
       tabs: [{ id: "description" }, { id: "details" }],
-      initial: "details",
+      initial: "description",
       labelPrefix: "CO.sheet.tabs.feature",
     },
   }

--- a/module/applications/sheets/path-sheet.mjs
+++ b/module/applications/sheets/path-sheet.mjs
@@ -20,7 +20,7 @@ export default class CoPathSheet extends CoBaseItemSheet {
   static TABS = {
     primary: {
       tabs: [{ id: "description" }, { id: "details" }],
-      initial: "details",
+      initial: "description",
       labelPrefix: "CO.sheet.tabs.path",
     },
   }

--- a/module/applications/sheets/profile-sheet.mjs
+++ b/module/applications/sheets/profile-sheet.mjs
@@ -20,7 +20,7 @@ export default class CoProfileSheet extends CoBaseItemSheet {
   static TABS = {
     primary: {
       tabs: [{ id: "description" }, { id: "details" }],
-      initial: "details",
+      initial: "description",
       labelPrefix: "CO.sheet.tabs.profile",
     },
   }


### PR DESCRIPTION
Comme demandé dans l'issue Fix #259 j'ai mis comme onglet de départ  "Description" plutôt que "Détails"