### PR TITLE
sans option jet combiné masquer options tactiques

### DIFF
--- a/templates/dialogs/attack-roll-dialog.hbs
+++ b/templates/dialogs/attack-roll-dialog.hbs
@@ -96,8 +96,7 @@
                 </div>  
             </div>
         </fieldset>           
-    {{/if}}
-
+        
     <section class="tacticalTargets">   
     <fieldset class="tacticalOptions">      
         <legend>{{localize "CO.ui.optionsTactiques"}}</legend>
@@ -122,7 +121,8 @@
                 </div>
             </div>
         </div>
-    </fieldset> 
+    </fieldset>
+    {{/if}} 
     <fieldset class="targetsBox">
         <legend>{{localize "CO.ui.attackTarget"}}</legend>
         <div class="targets center">


### PR DESCRIPTION
Pour masquer les Options tactiques de la fenêtre d'attaque lorsque l'option des Jets combinés n'est pas activé.
https://github.com/BlackBookEditions/foundry-co2/issues/293