### PR TITLE
fix_325 - control on learning path

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -371,6 +371,7 @@
       "warningProfileCreated": "Le profil a été créé.",
       "warningNotEnoughMana": "Pas assez de mana pour lancer le sort.",
       "warningLevelTooLow": "Vous n'avez pas le niveau minimum pour apprendre cette capacité.",
+      "warningTargetCapacityRankLowerThanPathRank": "Vous connaissez une capacité d'un rang supèrieur à celui de \"{capacityName}\" dans cette voie.",
       "warningApplyDamageNoTarget": "Vous devez sélectionner au moins une cible pour appliquer les dommages",
       "warningNoMoreRecoveryPoints": "Vous n'avez plus de dés de récupération.",
       "warningNoAmmo": "Vous n'avez plus de munitions.",


### PR DESCRIPTION
Suite au ticket [325](https://github.com/BlackBookEditions/foundry-co2/issues/325), ajout de controle pour décocher les capacité:
par exemple j'apprend les capacités 1 , 2 et 3 d'un voie. je décoche la capacité 2, alors la 3 se décoche également

lors que j'édite une capacité lié à un acteur, si les règles d'apprentissage ne sont pas réuni, alors la coche "apprendre" reste grisé