### PR TITLE
masquage sur les Actors des icones et champs en mode Observateur #322

### DIFF
--- a/templates/actors/character-biography.hbs
+++ b/templates/actors/character-biography.hbs
@@ -76,12 +76,14 @@
                 {{formInput systemFields.details.fields.biography.fields.public enriched=enrichedBiographyPublic value=system.details.biography.public name="system.details.biography.public" toggled=true}}
             </div>
         </div>
+        {{#unless (or viewLimited viewObserver)}}
         <div class="notes-section">
             <label class="details-label">{{localize "CO.ui.private"}}</label>
             <div class="notes-text">
                 {{formInput systemFields.details.fields.biography.fields.private enriched=enrichedBiographyPrivate value=system.details.biography.private name="system.details.biography.private" toggled=true}}
             </div>
         </div>
+        {{/unless}}
     </div>
 
     <h4 class="form-header"><a data-action="toggleSection" data-toggle-type="biography-appearance">{{localize "CO.ui.appearance"}}</a></h4>
@@ -92,11 +94,13 @@
                  {{formInput systemFields.details.fields.appearance.fields.public enriched=enrichedAppearancePublic value=system.details.appearance.public name="system.details.appearance.public" toggled=true}}
             </div>
         </div>
+        {{#unless (or viewLimited viewObserver)}} 
         <div class="notes-section">
             <label class="details-label">{{localize "CO.ui.private"}}</label>
             <div class="notes-text">
                 {{formInput systemFields.details.fields.appearance.fields.private enriched=enrichedAppearancePrivate value=system.details.appearance.private name="system.details.appearance.private" toggled=true}}
             </div>
         </div>
+        {{/unless}}
     </div>
 </section>

--- a/templates/actors/character-inventory.hbs
+++ b/templates/actors/character-inventory.hbs
@@ -27,12 +27,14 @@
       </h4>
       <div class="item-detail">{{localize "CO.ui.usage"}}</div>
       <div class="item-detail">{{localize "CO.label.short.quantity"}}</div>
+      {{#unless @root.viewObserver}} 
         <div class="item-detail">{{localize "CO.ui.actions"}}</div>
         <div class="item-controls-2">
-          {{#if @root/unlocked}}
+          {{#if @root.unlocked}}
             <a class="item-control" data-action="createItem" data-type="equipment" data-subtype="{{group.category}}" data-tooltip="{{localize 'CO.label.long.add'}}"><i class="fas fa-plus"></i></a>
           {{/if}}
         </div>
+      {{/unless}} 
     </li>
     <ol class="item-list foldable {{ifThen group.expanded 'expanded' 'folded'}}">
       {{#each group.items as |item id|}}
@@ -75,7 +77,9 @@
             </a>
           </div>
           <!-- Actions -->
+          {{#unless @root.viewObserver}} 
           <div class="item-detail">
+          
             {{#if item.system.properties.equipable}}
               {{#if item.system.equipped}}
                 <a class="item-control" data-action="inventoryEquip" style="color: green;" data-tooltip="{{localize 'CO.action.unequip'}}"><i class="fa-solid fa-shield"></i></a>
@@ -97,15 +101,21 @@
                 <a class="item-control inventory-consume" style="color: grey;" data-tooltip="{{localize 'CO.action.noCharge'}}"><i class="fa-regular fa-bullseye-arrow"></i></a>
               {{/if}}
             {{/if}}
+          
           </div>
+          {{/unless}}
           <!-- Boutons -->
+          {{#unless @root.viewObserver}} 
           <div class="item-controls-2">
+            
             <a class="chat" data-action="sendToChat" data-chat-type="item" data-tooltip="{{localize 'CO.label.long.sendToChat'}}"><i class="fas fa-fw fa-comment-alt"></i></a>
             {{#if @root/unlocked}}
               <a class="item-edit" data-action="editItem" data-tooltip="{{localize 'CO.label.long.edit'}}"><i class="fas fa-fw fa-edit"></i></a>
               <a class="item-control" data-action="deleteItem" data-tooltip="{{localize 'CO.ui.remove'}}"><i class="fas fa-trash"></i></a>
             {{/if}}
+            
           </div>
+          {{/unless}}
         </li>
       {{/each}}
     </ol>

--- a/templates/actors/character-main.hbs
+++ b/templates/actors/character-main.hbs
@@ -5,6 +5,7 @@
         <div class="section-header">
             <h4>{{localize "CO.ui.actions"}}</h4>
             <div class="actions-controls controls">
+                {{#unless viewObserver}} 
                 <div class="sheet-controls">
                     <button type="button" class="btn-mini-sheet" data-action="openMiniSheet" data-tooltip="Vue actions">
                         <i class="fa-solid fa-star"></i>
@@ -30,6 +31,7 @@
                     data-effect="fullDef">
                         <i class="fa-solid fa-shield {{#if fullDef}}enabled{{else}}disabled{{/if}} toggle-effect"></i>
                 </a>
+                {{/unless}}
             </div>
         </div>
         <!-- ACTIONS -->

--- a/templates/actors/encounter-main.hbs
+++ b/templates/actors/encounter-main.hbs
@@ -6,6 +6,7 @@
         <div class="section-header">
             <h4>{{localize "CO.label.long.attacks"}}</h4>
             <div class="actions-controls controls" style="margin-right:5px">
+                {{#unless viewObserver}}
                   <a class="item-control"
                     data-tooltip-direction="UP" 
                     data-tooltip="{{#if partialDef}}{{localize 'CO.customStatus.partialDefDeactivate'}}{{else}}{{localize 'CO.customStatus.partialDefActivate'}}{{/if}}" 
@@ -20,6 +21,7 @@
                     data-effect="fullDef">
                     <i class="fa-solid fa-shield {{#if fullDef}}enabled{{else}}disabled{{/if}} toggle-effect"></i>
                 </a>
+                {{/unless}}
             </div>
             {{#if unlocked}}
                 <div class="attacks-controls controls">
@@ -45,16 +47,19 @@
                                 {{attack.system.displayValues.attack}} <strong>  DM </strong>{{attack.system.displayValues.damage}}
                             </h4>
                             <div class="attack-controls controls">
+                                {{#unless ../viewObserver}}
                                 <a class="chat" data-action="sendToChat" data-chat-type="item" data-tooltip="{{localize 'CO.label.long.sendToChat'}}"
                                     ><i class="fas fa-fw fa-comment-alt"></i></a>
                                 {{#if ../unlocked}}
                                 <a class="edit" data-action="editItem" data-tooltip="{{localize 'CO.label.long.edit'}}"><i class="fas fa-fw fa-edit"></i></a>
                                 <a class="delete" data-action="deleteItem" data-tooltip="{{localize 'CO.label.long.delete'}}"><i class="fas fa-fw fa-trash"></i></a>
                                 {{/if}}
+                                {{/unless}}
                             </div>
                         </div>
                         <div class="attack-body">
                             <div class="flexrow">
+                                {{#unless ../viewObserver}}
                                 <div class="attacks sub-section">
                                     <button type="button" class="btn attack-button toggle-action"
                                         data-action="toggleAction" data-action-type="activate" data-type="attack" data-source="{{attack.uuid}}"
@@ -67,6 +72,7 @@
                                         data-indice="0">{{localize "CO.label.long.damage"}}
                                         {{attack.system.displayValues.damage}}</button>
                                 </div>
+                                {{/unless}}
                             </div>
                             <div class="attack-detail sub-section expandable expanded">
                                 <div class="attack-description">{{{attack.system.description}}}</span></div>

--- a/templates/actors/encounter-notes.hbs
+++ b/templates/actors/encounter-notes.hbs
@@ -9,6 +9,7 @@
             </div>
         </div>
     </div>
+    {{#unless (or viewLimited viewObserver)}}
     <div class="notes foldable">
         <div class="notes-section private-notes">
             <label class="details-label">{{localize "CO.ui.private"}}</label>
@@ -17,4 +18,5 @@
             </div>
         </div>
     </div>
+    {{/unless}}
 </section>

--- a/templates/actors/shared/actions.hbs
+++ b/templates/actors/shared/actions.hbs
@@ -22,7 +22,8 @@
                                         {{/each}}</h4></div>
                                     </div>
                                         
-                                </div>                            
+                                </div>
+                                {{#unless ../viewObserver}}                            
                                 <div class="item-controls-3">
                                     {{#each action.getActionIcons as |icon|}}
                                         <a class="item-control">
@@ -39,6 +40,7 @@
                                     {{/each}}
                                     <a class="chat" data-action="sendToChat" data-chat-type="action" data-indice="{{action.indice}}" data-source="{{action.source}}" data-tooltip="{{localize 'CO.label.long.sendToChat'}}"><i class="fas fa-fw fa-comment-alt"></i></a>
                                 </div>
+                                {{/unless}}
                             </li>
                     {{/each}}
                 </ol>


### PR DESCRIPTION
Attention avec la branche visibilityLimited sur les fichiers : 
 - templates\actors\encounter-notes.hbs
 - templates\actors\character-biography.hbs

car la balise entre en conflit avec ce commit pour masquer les champs Privés
{{#unless (or viewLimited viewObserver)}} doit remplacé {{#unless viewLimited}}
