### PR TITLE
Corrige la méthode `sendToChat`

### DIFF
--- a/module/macros.mjs
+++ b/module/macros.mjs
@@ -68,6 +68,7 @@ export default class Macros {
           .withTemplate("systems/co2/templates/chat/item-card.hbs")
           .withData({
             actorId: actor.id,
+            actorUuid: actor.uuid,
             id: itemChatData.id,
             uuid: itemChatData.uuid,
             name: itemChatData.name,
@@ -86,6 +87,7 @@ export default class Macros {
           .withTemplate("systems/co2/templates/chat/item-card.hbs")
           .withData({
             actorId: actor.id,
+            actorUuid: actor.uuid,
             id: itemChatData.id,
             uuid: itemChatData.uuid,
             name: itemChatData.name,


### PR DESCRIPTION
Reproduit le comportement des fiches de personnage pour la méthode `sendToChat` qui n'envoie pas l'UUID de l'acteur courant.