### PR TITLE
correction de la vision par defaut des rencontres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Corrige un bug qui pouvait empêcher l'ouverture d'une fiche de personnage qui avait un effet lui infligeant des dommages périodiques en combat
 - Corrige un bug qui empêchait le calcul d'une difficulté s'il y avait une formule dedans (ex : 10 + 1) (issue [#335](https://github.com/BlackBookEditions/foundry-co2/issues/335))
 - Correction de la formule des dommages dans le cas du dé évolutif (issue [#341](https://github.com/BlackBookEditions/foundry-co2/issues/341))
+- Correction de la vision des rencontres qui à la création avaient la vision activée par défaut (issue [#347](https://github.com/BlackBookEditions/foundry-co2/issues/347))
 
 # 1.2.1
 ## Corrections

--- a/module/models/encounter.mjs
+++ b/module/models/encounter.mjs
@@ -109,7 +109,7 @@ export default class EncounterData extends ActorData {
     const updates = {
       prototypeToken: {
         sight: {
-          enabled: true,
+          enabled: false,
           visionMode: "basic",
         },
       },


### PR DESCRIPTION
Pour la creation du prototype token j'ai mis la vision sur false au lieu de true. Ainsi toutes nouvelles rencontre aura la vision desactivée.
Attention ça ne corrige pas les rencontre déjà créé car potentiellement ça pouvais etre un désir du MJ..
Fix #347 
