### PR TITLE
Dev fix356

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Ajout d'une option de durée "illimité" sur le seffets supplémentaire qui peux maintenant s'activer hors combat et devra donc se supprimer manuellement. Permet des effets qui n'ont pas de notions de durée.(issue [#355](https://github.com/BlackBookEditions/foundry-co2/issues/355))
 
+## Corrections
+
+- Correction d'un bug qui empêchait l'affichage de la fenêtre de jet de compétences en cas où le joueur avait été ciblé par un buff provenant d'un autre joueur et augmentant son jet de compétences [#356](https://github.com/BlackBookEditions/foundry-co2/issues/356))
+
 # 1.3.1
 
 ## Améliorations

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -561,19 +561,20 @@ export default class COActor extends Actor {
     const modifiersByTarget = this.system.skillModifiers.filter((m) => m.target === ability)
     // Ajout des modifiers qui affecte toutes les cibles
     modifiersByTarget.push(...this.system.skillModifiers.filter((m) => m.target === SYSTEM.MODIFIERS_TARGET.all.id))
-    // Si le modifier est d'origine d'un customEffectData il ne faut pas chercher sa source
+
     let bonuses = []
     for (const modifier of modifiersByTarget) {
-      if (!modifier.parent) {
+      // Si le modifiera pour origine un customEffectData, il ne faut pas chercher sa source
+      if (!modifier.parent || modifier.parent instanceof CustomEffectData) {
         const customeffect = this.system.currentEffects.find((e) => e.source === modifier.source)
         if (customeffect) {
           bonuses.push({
             sourceType: "CustomEffectData",
             name: customeffect.name,
             description: customeffect.name,
-            pathType: "",
+            pathType: game.i18n.localize("CO.label.long.effects"),
             value: modifier.evaluate(this),
-            additionalInfos: "",
+            additionalInfos: modifier.additionalInfos,
           })
         }
       } else {


### PR DESCRIPTION
Fix #356 Corrige la zone qui gère l'afrfichage des infos de bonus au jet de compétence en testant si la source est un CustomEffect ou non.

<img width="1226" height="658" alt="image" src="https://github.com/user-attachments/assets/cdd5286b-1cc0-4f97-88e5-066656404c45" />
