### PR TITLE
ajout de la fenetre de jet de competence sur les jets opposé

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Ajout de la prise en charge d'un effet supplémentaire illimité et utilisable hors des combats
 - Attaque automatique : affichage des cibles
 - Ajout de l'affichage d'un message indiquant qui a lancé un buff/debuff sur quelles cibles (issue [#363](https://github.com/BlackBookEditions/foundry-co2/issues/363))
+- Ajout de l'affichage de la fenêtre de jet de compétences si une attaque opposée s'oppose à un attribut du personnage (issue [#179](https://github.com/BlackBookEditions/foundry-co2/issues/179))
 
 ## Corrections
 

--- a/module/models/save-message.mjs
+++ b/module/models/save-message.mjs
@@ -227,7 +227,7 @@ export default class SaveMessageData extends BaseMessageData {
         const targetRollSkill = await targetActor.rollSkill(saveAbility, { difficulty: difficulty, showResult: false })
         message.system.result = targetRollSkill.result
         message.system.linkedRoll = targetRollSkill.roll
-
+        let opposeResultAnalyse = CORoll.analyseRollResult(targetRollSkill.roll)
         console.log("result : ", targetRollSkill.result)
 
         let rolls = this.parent.rolls


### PR DESCRIPTION
Fix #179  : Ajoute le lancement d'une fenetre de jet de compétences si le jet opposé se fait sur un des attribut (agi, con, ....)

<img width="1715" height="512" alt="image" src="https://github.com/user-attachments/assets/295e58bd-cedc-4c30-909e-85b9d55facf7" />

<img width="437" height="589" alt="image" src="https://github.com/user-attachments/assets/b3c8f0c7-b7ee-43c7-8f31-f0a9d2ecc9ef" />
