### PR TITLE
corrige le calcul de la difficulté des jets de sauvegarde

### DIFF
--- a/module/models/schemas/resolver.mjs
+++ b/module/models/schemas/resolver.mjs
@@ -256,6 +256,8 @@ export class Resolver extends foundry.abstract.DataModel {
     difficultyFormula = Utils.evaluateCoModifierWithDiceValue(actor, difficultyFormula, item.uuid)
     const resultat = await new Roll(difficultyFormula).evaluate()
     difficultyFormula = resultat.total.toString()
+    let difficultyFormulaEvaluated = Roll.replaceFormulaData(difficultyFormula, actor.getRollData())
+
     let showDifficulty = false
     const displayDifficulty = game.settings.get("co2", "displayDifficulty")
     showDifficulty = displayDifficulty === "all" || (displayDifficulty === "gm" && game.user.isGM)
@@ -278,7 +280,7 @@ export class Resolver extends foundry.abstract.DataModel {
     const save = await actor.rollAskSave(item, {
       actionName: action.label,
       ability: saveAbility,
-      difficulty: difficultyFormula,
+      difficulty: difficultyFormulaEvaluated,
       showDifficulty,
       targetType: this.target.type,
       targets: targets,


### PR DESCRIPTION
<img width="1271" height="348" alt="image" src="https://github.com/user-attachments/assets/d3ff5a46-75bf-4889-a06b-50d9964e57e5" />

J'ai corrigé le calcul de la difficulté de jets de sauvegarde en gérant tout type de formule sur le seuil au cas ou il pourrais y avoir des dés ou des variables

avant/apres : 
<img width="439" height="583" alt="image" src="https://github.com/user-attachments/assets/1cf98207-b37d-4237-97e3-e48ea0ec947c" />
