### PR TITLE
ajout asservi à la liste de status et tri

### DIFF
--- a/module/config/action.mjs
+++ b/module/config/action.mjs
@@ -259,50 +259,70 @@ export const RESOLVER_FORMULA_TYPE = Object.freeze({
 })
 
 export const RESOLVER_ADDITIONAL_EFFECT_STATUS = {
-  dead: {
-    id: "dead",
-    label: "CO.customStatus.dead",
+  weakened: {
+    id: "weakened",
+    label: "CO.customStatus.weakened",
   },
-  immobilized: {
-    id: "immobilized",
-    label: "CO.customStatus.immobilized",
-  },
-  stun: {
-    id: "stun",
-    label: "CO.customStatus.stun",
-  },
-  paralysis: {
-    id: "paralysis",
-    label: "CO.customStatus.paralysis",
+  enslaved: {
+    id: "enslaved",
+    label: "CO.customStatus.enslaved",
   },
   blind: {
     id: "blind",
     label: "CO.customStatus.blind",
   },
-  silence: {
-    id: "silence",
-    label: "CO.customStatus.silence",
-    img: "icons/svg/silenced.svg",
-  },
-  outOfBreath: {
-    id: "outOfBreath",
-    label: "CO.customStatus.outOfBreath",
-  },
-  bleeding: {
-    id: "bleeding",
-    label: "CO.customStatus.bleeding",
-  },
-  invalid: {
-    id: "invalid",
-    label: "CO.customStatus.invalid",
+  confused: {
+    id: "confused",
+    label: "CO.customStatus.confused",
   },
   poison: {
     id: "poison",
     label: "CO.customStatus.poison",
   },
+  bleeding: {
+    id: "bleeding",
+    label: "CO.customStatus.bleeding",
+  },
+  outOfBreath: {
+    id: "outOfBreath",
+    label: "CO.customStatus.outOfBreath",
+  },
+  stun: {
+    id: "stun",
+    label: "CO.customStatus.stun",
+  },
+  immobilized: {
+    id: "immobilized",
+    label: "CO.customStatus.immobilized",
+  },
+  unconscious: {
+    id: "unconscious",
+    label: "CO.customStatus.unconscious",
+  },
+  invalid: {
+    id: "invalid",
+    label: "CO.customStatus.invalid",
+  },
+  invisible: {
+    id: "invisible",
+    label: "CO.customStatus.invisible",
+  },
+  dead: {
+    id: "dead",
+    label: "CO.customStatus.dead",
+  },
+  paralysis: {
+    id: "paralysis",
+    label: "CO.customStatus.paralysis",
+  },
   slowed: {
     id: "slowed",
     label: "CO.customStatus.slowed",
+  },
+  silence: {
+    id: "silence",
+    label: "CO.customStatus.silence",
+    img: "icons/svg/silenced.svg",
   },
   overturned: {
     id: "overturned",
@@ -311,21 +331,5 @@ export const RESOLVER_ADDITIONAL_EFFECT_STATUS = {
   surprised: {
     id: "surprised",
     label: "CO.customStatus.surprised",
-  },
-  weakened: {
-    id: "weakened",
-    label: "CO.customStatus.weakened",
-  },
-  invisible: {
-    id: "invisible",
-    label: "CO.customStatus.invisible",
-  },
-  unconscious: {
-    id: "unconscious",
-    label: "CO.customStatus.unconscious",
-  },
-  confused: {
-    id: "confused",
-    label: "CO.customStatus.confused",
   },
 }


### PR DESCRIPTION
j'avais ajouté l'etat asservi mais il n'apparaissait pas dans la liste des status des effets supplémentaire. Je l'ia donc ajouté et j'ai trié dans l'ordre alphabétique