### PR TITLE
correction CSS en theme sombre save-chat

### DIFF
--- a/css/co.css
+++ b/css/co.css
@@ -3621,6 +3621,13 @@ co-toggle-switch[checked] thumb {
   padding: 0px 5px;
   margin: 0 0 5px 0;
 }
+#interface #sidebar .co.chat-card.roll-card.save-card .card-content .save-roll .save-title,
+#interface #ui-right-column-1 .co.chat-card.roll-card.save-card .card-content .save-roll .save-title,
+#interface #sidebar .co.chat-card.roll-card.save-card .card-content .save-roll .save-skill,
+#interface #ui-right-column-1 .co.chat-card.roll-card.save-card .card-content .save-roll .save-skill {
+  color: inherit;
+  padding: 0;
+}
 #interface #sidebar .co.chat-card.roll-card.save-card .card-content .save-roll .save-skill,
 #interface #ui-right-column-1 .co.chat-card.roll-card.save-card .card-content .save-roll .save-skill {
   font-weight: bold;

--- a/styles/applications/chat/save-card.less
+++ b/styles/applications/chat/save-card.less
@@ -31,7 +31,10 @@
       box-shadow: 1px 1px 0px 1px var(--color-chatSave);
       padding: 0px 5px;
       margin: 0 0 5px 0;
-      .save-title {
+      .save-title,
+      .save-skill {
+        color: inherit;
+        padding: 0;
       }
       .save-skill {
         font-weight: bold;


### PR DESCRIPTION
Juste une petite correction du CSS pour le thème sombre sur le message chat des jets de sauvegarde au niveau du bouton