### PR TITLE
Seuil succes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
-#  1.5.0
+# 1.5.0
 
 ## Améliorations
+
 - Drop d'un action dans la hotbar : amélioration des différents raccourcis selon le type d'action
-| Type d'action                      │        Clic        │ Alt+Clic │ Ctrl+Clic │ Shift+Clic │
-│ Temporaire (activable/désactivable)│ Activer/Désactiver │ -        │ Chat      │ Fiche      │
-│ Attaque avec dommages (mêlée, distance, magique, sort)  │ Attaque            │ Dommages │ Chat      │ Fiche │
-│ Attaque sans dommages                                   │ Attaque            │ -        │ Chat      │ Fiche │
-│ Autres (soin, buff, debuff, consommable, auto)          │ Utiliser           │ -        │ Chat      │ Fiche |
+  | Type d'action │ Clic │ Alt+Clic │ Ctrl+Clic │ Shift+Clic │
+  │ Temporaire (activable/désactivable)│ Activer/Désactiver │ - │ Chat │ Fiche │
+  │ Attaque avec dommages (mêlée, distance, magique, sort) │ Attaque │ Dommages │ Chat │ Fiche │
+  │ Attaque sans dommages │ Attaque │ - │ Chat │ Fiche │
+  │ Autres (soin, buff, debuff, consommable, auto) │ Utiliser │ - │ Chat │ Fiche |
 - Voies : possibilité de réorganiser l'ordre des voies par glisser-déposer dans l'onglet Voies
 - Chat : SHIFT+clic sur le bouton d'envoi au chat envoie le message en mode public (visible par tous) au lieu du mode privé (MJ uniquement)
 - Affichage du nombre d'actions configurées entre parenthèses dans l'onglet Actions/Effets des fiches d'objets (capacité, équipement, attaque). Le compteur ne s'affiche que si au moins une action est configurée.
@@ -15,8 +16,10 @@
 - Modificateurs des Traits et Profils : harmonisation de l'interface des modificateurs avec celle des capacités et équipement. Les modificateurs ne s'appliquent qu'à soi-même.
 - Jet de sauvegarde : affichage d'un ? avant le jet
 - Onglet des actions : symbole d'une balance si c'est un test opposé (@oppose dans la difficulté)
+- Ajout d'une option de resolver : Seuil de succes pour gérer les cas de succès d'attaque automatique au delà d'une valeur de jet de dé. Ajout d'un declencheur de resolver si le resultat est au dessus du seuil de succes défini. Ajout d'une condition d'application d'effets supplémentaire via le dépassement du seuil de succes
 
 ## Corrections
+
 - Mode Lecture des fiches d'objets : les champs de formulaire (input, select, checkbox) et les images sont maintenant correctement en lecture seule
 - Jet de compétence : correction de l'affichage de la source des bonus pour les capacités. Affichage de la voie.
 - Un effet additionnel n'est créé que s'il est actif
@@ -24,15 +27,18 @@
 # 1.4.2
 
 ## Améliorations
+
 - Les dommages ne sont pas lancés si la formule vaut 0
 
 ## Corrections
+
 - Utilisation du point de chance sur un jet d'attaque
 - Corrige une erreur sur la résolution de type jet opposé
 
 # 1.4.1
 
 ## Corrections
+
 - Les dommages n'étaient plus lancés en cas de succès au jet d'attaque. Par contre, ils sont lancés même si la formule vaut 0 (comme 0+0).
 - Affichage du jet de sauvegarde avec le thème sombre
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Modificateurs des Traits et Profils : harmonisation de l'interface des modificateurs avec celle des capacités et équipement. Les modificateurs ne s'appliquent qu'à soi-même.
 - Jet de sauvegarde : affichage d'un ? avant le jet
 - Onglet des actions : symbole d'une balance si c'est un test opposé (@oppose dans la difficulté)
-- Ajout d'une option de resolver : Seuil de succes pour gérer les cas de succès d'attaque automatique au delà d'une valeur de jet de dé. Ajout d'un declencheur de resolver si le resultat est au dessus du seuil de succes défini. Ajout d'une condition d'application d'effets supplémentaire via le dépassement du seuil de succes
+- Ajout d'une option de resolver : Seuil de succès pour gérer les cas de succès d'attaque automatique au-delà d'une valeur de jet de dé. Ajout d'un déclencheur de resolver si le résultat est au-dessus du seuil de succès défini. Ajout d'une condition d'application d'effets supplémentaires via le dépassement du seuil de succès
 
 ## Corrections
 

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1094,12 +1094,14 @@
         "all": "Tout le monde",
         "title": "Catégorie"
       },
+      "hasAttackSuccessThreshold": "Seuil de succès automatique",
       "additionalEffect": {
         "active": "Effets supplémentaires",
         "applyOn": "s'applique",
         "onSuccess": "sur un succès",
         "onCritical": "sur un succès critique",
         "onSuccessTreshold": "à partir d'un succès + ",
+        "onAttackSuccessTreshold": "Entre le seuil et 20",
         "onFailure": "sur un échec",
         "always": "toujours",
         "onSaveFailure": "si échec de sauvegarde",

--- a/module/config/action.mjs
+++ b/module/config/action.mjs
@@ -211,6 +211,7 @@ export const RESOLVER_SCOPE = Object.freeze({
  * @property {Object} always - Effect that always triggers
  * @property {Object} success - Effect that triggers on success
  * @property {Object} successTreshold - Effect that triggers when success meets threshold
+ * @property {Object} attackSuccessTreshold - Effect that triggers when dice result is between attackSuccessTreshold and 20.
  * @property {Object} critical - Effect that triggers on critical success
  * @property {Object} failure - Effect that triggers on failure
  * @property {Object} saveFailure - Effect that triggers on save failure
@@ -228,6 +229,10 @@ export const RESOLVER_RESULT = Object.freeze({
   successTreshold: {
     id: "successTreshold",
     label: "CO.resolver.additionalEffect.onSuccessTreshold",
+  },
+  attackSuccessTreshold: {
+    id: "attackSuccessTreshold",
+    label: "CO.resolver.additionalEffect.onAttackSuccessTreshold",
   },
   critical: {
     id: "critical",

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1841,6 +1841,8 @@ export default class COActor extends Actor {
       customEffect,
       additionalEffect,
       tactical = undefined, // Values : confident, precise, violent
+      hasAttackSuccessThreshold = false,
+      attackSuccessThreshold = undefined,
     } = {},
   ) {
     const options = {
@@ -1871,6 +1873,8 @@ export default class COActor extends Actor {
       customEffect,
       additionalEffect,
       tactical,
+      hasAttackSuccessThreshold,
+      attackSuccessThreshold,
     }
     /**
      * A hook event that fires before the roll is made.
@@ -2085,6 +2089,8 @@ export default class COActor extends Actor {
       hasLuckyPoints,
       opposeResult: opposeResult,
       opposeTooltip: opposeTooltip,
+      hasAttackSuccessThreshold: hasAttackSuccessThreshold,
+      attackSuccessThreshold: attackSuccessThreshold,
     }
 
     // Rolls contient le jet d'attaque et le jet de dommages si le type est "attack"
@@ -2102,7 +2108,7 @@ export default class COActor extends Actor {
      */
     if (Hooks.call("co.postRollAttack", item, options, rolls) === false) return
 
-    let results = rolls.map((roll) => CORoll.analyseRollResult(roll))
+    let results = rolls.map((roll) => CORoll.analyseRollResult(roll, hasAttackSuccessThreshold, attackSuccessThreshold))
     /**
      * A hook event that fires before the results of the roll.
      * @function co.resultRollAttack

--- a/module/documents/roll.mjs
+++ b/module/documents/roll.mjs
@@ -5,9 +5,11 @@ export class CORoll extends Roll {
   /**
    * Fonction qui va analyser les valeurs du jet de dé et indiquer s'il s'agit d'un succes ou non ainsi que les infos
    * @param {*} roll
-   * @returns { diceResult, total, isCritical, isFumble, difficulty, isSuccess, isFailure } ou {} si le roll n'est pas un COAttackRoll de type "attack" ou COSkillRoll
+   * @param {Boolean} hasAttackSuccessThreshold Indique si l'attaque avait un seuil de succès automatique
+   * @param {Number} attackSuccessThreshold Seuil à partir duquel on a un succès automatique
+   * @returns { diceResult, total, isCritical, isFumble, difficulty, isSuccess, isFailure, isSuccessThreshold } ou {} si le roll n'est pas un COAttackRoll de type "attack" ou COSkillRoll
    */
-  static analyseRollResult(roll) {
+  static analyseRollResult(roll, hasAttackSuccessThreshold = false, attackSuccessThreshold = 20) {
     let result = {}
 
     // Vérification du type de roll
@@ -24,6 +26,7 @@ export class CORoll extends Roll {
       let difficulty = roll.options.difficulty
       let isSuccess
       let isFailure
+      let isSuccessThreshold = false
       // Si on utilise une difficulté et qu'elle a été définie
       // Si elle n'est pas saisie dans la fenêtre de dialogue, difficulty vaut ""
       if (roll.options.useDifficulty && difficulty && difficulty !== "") {
@@ -36,9 +39,17 @@ export class CORoll extends Roll {
           isFailure = roll.total < difficulty
         }
       }
+      console.log("hasAttackSuccessThreshold", hasAttackSuccessThreshold, "attackSuccessThreshold", attackSuccessThreshold)
+      if (hasAttackSuccessThreshold && diceResult >= attackSuccessThreshold) {
+        console.log("L'attaque a depassé le seuil de succès automatique", diceResult, attackSuccessThreshold)
+        isSuccess = true // Si on aun seuil de succès automatique et que le dé est au dessus alors on a un succès
+        isSuccessThreshold = true
+        isFailure = false
+      }
       if (isCritical) isSuccess = true
       if (isFumble) isFailure = true
-      result = { diceResult, total, isCritical, isFumble, difficulty, isSuccess, isFailure }
+
+      result = { diceResult, total, isCritical, isFumble, difficulty, isSuccess, isFailure, isSuccessThreshold }
     }
     return result
   }
@@ -461,6 +472,8 @@ export class COAttackRoll extends CORoll {
         tactical: withDialog ? rollContext.tactical : dialogContext.tactical,
         opposeResult: dialogContext.opposeResult,
         opposeTooltip: dialogContext.opposeTooltip,
+        hasAttackSuccessThreshold: dialogContext.hasAttackSuccessThreshold,
+        attackSuccessThreshold: dialogContext.attackSuccessThreshold,
         ...options,
       }
 
@@ -531,7 +544,7 @@ export class COAttackRoll extends CORoll {
    * @private
    */
   _getAttackChatCardData(flavor, isPrivate) {
-    const rollResults = CORoll.analyseRollResult(this)
+    const rollResults = CORoll.analyseRollResult(this, this.options.hasAttackSuccessThreshold, this.options.attackSuccessThreshold)
     if (CONFIG.debug.co2?.chat) console.debug(Utils.log(`COAttackRoll - _getAttackChatCardData options`), this.options)
 
     // Gestion des dés bonus/malus

--- a/module/documents/roll.mjs
+++ b/module/documents/roll.mjs
@@ -39,9 +39,8 @@ export class CORoll extends Roll {
           isFailure = roll.total < difficulty
         }
       }
-      console.log("hasAttackSuccessThreshold", hasAttackSuccessThreshold, "attackSuccessThreshold", attackSuccessThreshold)
+
       if (hasAttackSuccessThreshold && diceResult >= attackSuccessThreshold) {
-        console.log("L'attaque a depassé le seuil de succès automatique", diceResult, attackSuccessThreshold)
         isSuccess = true // Si on aun seuil de succès automatique et que le dé est au dessus alors on a un succès
         isSuccessThreshold = true
         isFailure = false

--- a/module/models/character.mjs
+++ b/module/models/character.mjs
@@ -845,7 +845,6 @@ export default class CharacterData extends ActorData {
 
       // Dépense du DR
       newRp.value = rp.value - 1
-      console.log("on met à jour les rp", newRp)
       await this.parent.update({ "system.resources.recovery": newRp })
     }
     // Récupération complète

--- a/module/models/save-message.mjs
+++ b/module/models/save-message.mjs
@@ -202,19 +202,19 @@ export default class SaveMessageData extends BaseMessageData {
         event.stopPropagation()
         const messageId = event.currentTarget.closest(".message").dataset.messageId
         if (!messageId) {
-          console.log("Evenement de click sur le bouton de jet de sauvegarde : erreur dans la récupération de l'ID du message")
+          console.error("Evenement de click sur le bouton de jet de sauvegarde : erreur dans la récupération de l'ID du message")
           return
         }
         const message = game.messages.get(messageId)
         if (!message || !message.system) {
-          console.log("Evenement de click sur le bouton de jet de sauvegarde : erreur dans la récupération du message ou de son context")
+          console.error("Evenement de click sur le bouton de jet de sauvegarde : erreur dans la récupération du message ou de son context")
           return
         }
 
         const dataset = event.currentTarget.dataset
         const targetUuid = message.system.targets[0]
         if (!targetUuid) {
-          console.log("Evenement de click sur le bouton de jet de sauvegarde : erreur dans la récupération de l'UUID de la cible")
+          console.error("Evenement de click sur le bouton de jet de sauvegarde : erreur dans la récupération de l'UUID de la cible")
           return
         }
 
@@ -223,7 +223,7 @@ export default class SaveMessageData extends BaseMessageData {
 
         const targetActor = fromUuidSync(targetUuid)
         if (!targetActor) {
-          console.log("Evenement de click sur le bouton de jet de sauvegarde : erreur dans la récupération de l'acteur cible")
+          console.error("Evenement de click sur le bouton de jet de sauvegarde : erreur dans la récupération de l'acteur cible")
           return
         }
 
@@ -232,7 +232,6 @@ export default class SaveMessageData extends BaseMessageData {
         message.system.result = targetRollSkill.result
         message.system.linkedRoll = targetRollSkill.roll
         let opposeResultAnalyse = CORoll.analyseRollResult(targetRollSkill.roll)
-        console.log("result : ", targetRollSkill.result)
 
         let rolls = this.parent.rolls
         rolls[0] = targetRollSkill.roll
@@ -244,8 +243,6 @@ export default class SaveMessageData extends BaseMessageData {
         const customEffect = message.system.customEffect
         const additionalEffect = message.system.additionalEffect
         if (customEffect && additionalEffect && additionalEffect.active && Resolver.shouldManageAdditionalEffect(targetRollSkill.result, additionalEffect)) {
-          console.log("on va appliquer les effets", "customEffect : ", customEffect)
-
           if (game.user.isGM) await targetActor.applyCustomEffect(customEffect)
           else {
             await game.users.activeGM.query("co2.applyCustomEffect", { ce: customEffect, targets: [targetActor.uuid] })

--- a/module/models/schemas/resolver.mjs
+++ b/module/models/schemas/resolver.mjs
@@ -140,29 +140,22 @@ export class Resolver extends foundry.abstract.DataModel {
       attackSuccessThreshold: this.attackSuccessThreshold,
     })
     if (!attack) return false
-    console.log("voyons si je dois appliquer les effets")
     // Gestion des effets supplémentaires
     if (this.additionalEffect.active && Resolver.shouldManageAdditionalEffect(attack[0], this.additionalEffect)) {
-      console.log("je dois appliquer les effets")
       await this._manageAdditionalEffect(actor, item, action)
-    } else {
-      console.log("je ne dois pas appliquer les effets")
     }
 
     return true
   }
 
   static shouldManageAdditionalEffect(result, additionalEffect) {
-    console.log("Should manage additional effect", result, additionalEffect.applyOn, SYSTEM.RESOLVER_RESULT.attackSuccessTreshold.id)
     if (additionalEffect.applyOn === SYSTEM.RESOLVER_RESULT.always.id) return true
     if (additionalEffect.applyOn === SYSTEM.RESOLVER_RESULT.success.id && result.isSuccess) return true
     if (additionalEffect.applyOn === SYSTEM.RESOLVER_RESULT.successTreshold.id && result.isSuccess && result.total >= result.difficulty + additionalEffect.successThreshold)
       return true
     // Ajout des seuil de succès auto
-    if (additionalEffect.applyOn === SYSTEM.RESOLVER_RESULT.attackSuccessTreshold.id && result.isSuccess && result.isSuccessThreshold) {
-      console.log("shouldManageAdditionalEffect:je renvoi true")
-      return true
-    }
+    if (additionalEffect.applyOn === SYSTEM.RESOLVER_RESULT.attackSuccessTreshold.id && result.isSuccess && result.isSuccessThreshold) return true
+
     if (additionalEffect.applyOn === SYSTEM.RESOLVER_RESULT.saveSuccess.id && result.isSuccess) return true
     if (additionalEffect.applyOn === SYSTEM.RESOLVER_RESULT.saveFailure.id && !result.isSuccess && result.total) return true
     if (additionalEffect.applyOn === SYSTEM.RESOLVER_RESULT.critical.id && result.isCritical) return true
@@ -475,7 +468,6 @@ export class Resolver extends foundry.abstract.DataModel {
       slug: effectName.slugify(),
     })
 
-    console.log("Created custom effect :", ce)
     return ce
   }
 

--- a/module/models/schemas/resolver.mjs
+++ b/module/models/schemas/resolver.mjs
@@ -159,7 +159,7 @@ export class Resolver extends foundry.abstract.DataModel {
     if (additionalEffect.applyOn === SYSTEM.RESOLVER_RESULT.successTreshold.id && result.isSuccess && result.total >= result.difficulty + additionalEffect.successThreshold)
       return true
     // Ajout des seuil de succès auto
-    if (additionalEffect.applyOn === SYSTEM.RESOLVER_RESULT.attackSuccessTreshold.id && result.isSuccess && result.isSuccessTreshold) {
+    if (additionalEffect.applyOn === SYSTEM.RESOLVER_RESULT.attackSuccessTreshold.id && result.isSuccess && result.isSuccessThreshold) {
       console.log("shouldManageAdditionalEffect:je renvoi true")
       return true
     }

--- a/templates/items/parts/resolver-part.hbs
+++ b/templates/items/parts/resolver-part.hbs
@@ -99,6 +99,25 @@
       </div>
     </div>
   {{/unless}}
+  {{! Seuil de succes auto}}
+  {{#if (eq r.type @root.choiceResolverTypes.attack.id)}}
+  <div class="form-group effects">
+      <label class="checkbox">
+        <input type="checkbox" name="system.actions.{{idx}}.resolvers.{{id}}.hasAttackSuccessThreshold" {{checked r.hasAttackSuccessThreshold}} {{#if @root.locked}}class="disabled"{{/if}}/>
+        {{localize "CO.resolver.hasAttackSuccessThreshold"}}
+      </label>
+       {{#if r.hasAttackSuccessThreshold}}
+          <input
+              class="field-value"
+              name="system.actions.{{idx}}.resolvers.{{id}}.attackSuccessThreshold"
+              type="text"
+              value="{{r.attackSuccessThreshold}}"
+              data-dtype="String"
+              {{#if @root.locked}}readonly{{/if}}
+          />
+       {{/if}}
+  </div>
+  {{/if}}
 {{! Additional effects }}
 {{#unless (eq r.type @root.choiceResolverTypes.consumable.id)}}
     <div class="form-group effects">


### PR DESCRIPTION
Ajout de la possibilité de définir un seuil de succes automatique

<img width="911" height="298" alt="image" src="https://github.com/user-attachments/assets/a99c56a8-12d3-45c8-b780-cc1b8ccad04a" />

Si le jet de dé dépasse le seuil alors c'est du succes automatique et si succes automatique on peux declencher un effet supplementaire : 

<img width="451" height="815" alt="image" src="https://github.com/user-attachments/assets/0af88db3-a8e3-49e3-90a3-bf7cc1f227bf" />

Fix #117