### PR TITLE
Modification du CSS de l'ionglet Biographie (plus compact)

### DIFF
--- a/css/co.css
+++ b/css/co.css
@@ -2851,8 +2851,11 @@ co-toggle-switch[checked] thumb {
 .co.application.sheet.actor.character .features-container .item-list {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
-  padding: 5px 10px 0px 10px;
-  column-gap: 20px;
+  padding: 0px 10px 0px 10px;
+  column-gap: 10px;
+}
+.co.application.sheet.actor.character .features-container.items-container {
+  margin-bottom: 2px;
 }
 .co.application.sheet.actor.character .features.section-container {
   margin: 0;
@@ -2879,6 +2882,23 @@ co-toggle-switch[checked] thumb {
 .co.application.sheet.actor.character section.biography .bio.folded,
 .co.application.sheet.actor.character section.biography .appearance.folded {
   display: none;
+}
+.co.application.sheet.actor.character .notes-section {
+  border-top: 1px dashed var(--color-abilities);
+}
+.co.application.sheet.actor.character .tab.standard-form.biography.active {
+  gap: 0;
+}
+.co.application.sheet.actor.character .bio-misc {
+  display: grid;
+  grid-template-columns: 0.4fr 1fr;
+  column-gap: 10px;
+}
+.co.application.sheet.actor.character .bio-languages {
+  margin-right: 5px;
+}
+.co.application.sheet.actor.character .bio-languages label {
+  flex: 0;
 }
 .co.application.sheet.actor.character .btn-sort-items-default,
 .co.application.sheet.actor.character .btn-sort-items-rank,

--- a/styles/applications/sheets/actors/character.less
+++ b/styles/applications/sheets/actors/character.less
@@ -43,9 +43,13 @@
   .item-list {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
-    padding: 5px 10px 0px 10px;
-    column-gap: 20px;
+    padding: 0px 10px 0px 10px;
+    column-gap: 10px;
   }
+}
+
+.features-container.items-container {
+  margin-bottom: 2px;
 }
 
 .features.section-container {
@@ -78,6 +82,25 @@ section.biography {
     &.folded {
       display: none;
     }
+  }
+}
+.notes-section {
+  border-top: 1px dashed var(--color-abilities);
+}
+
+.tab.standard-form.biography.active {
+  gap: 0;
+}
+.bio-misc {
+  display: grid;
+  grid-template-columns: 0.4fr 1fr;
+  column-gap: 10px;
+}
+
+.bio-languages {
+  margin-right: 5px;
+  label {
+    flex: 0;
   }
 }
 

--- a/templates/actors/character-biography.hbs
+++ b/templates/actors/character-biography.hbs
@@ -42,44 +42,9 @@
             </div>
         </div>
     {{/unless}}
-    {{#if viewLimited}}
-        <div class="form-group">
-            <label>{{localize "CO.ui.size"}}</label>
-            <div class="form-fields">
-                <select data-action="sizeChange" name="system.details.size" data-type="String" {{#unless unlocked}}disabled{{/unless}} style="width:100%" >
-                    {{selectOptions choiceSize selected=details.size localize=true}}
-                </select>
-            </div>
-        </div>    
-    {{else}}
-        <h4 class="form-header"><a data-action="toggleSection" data-toggle-type="biography-misc">{{localize "CO.ui.misc"}}</a></h4>
-        <div class="misc foldable {{ifThen biographyMiscExpanded 'expanded' 'folded'}}">
-            <div class="form-group">
-                <label>{{localize "CO.ui.size"}}</label>
-                <div class="form-fields">
-                    <select data-action="sizeChange" name="system.details.size" data-type="String" class="{{#unless unlocked}}disabled{{/unless}}" style="width:100%" >
-                        {{selectOptions choiceSize selected=details.size localize=true}}
-                    </select>
-                </div>
-            </div>
-            <div class="form-group">
-                <label>{{localize "CO.ui.languages"}}</label>
-                <div class="form-fields">
-                <input
-                    class="field-value"
-                    name="system.details.languages"
-                    type="text"
-                    value="{{system.details.languages}}"
-                    placeholder="{{localize 'CO.ui.languages'}}"
-                    data-dtype="String"
-                    {{#unless unlocked}}readonly{{/unless}}
-                />
-                </div>
-            </div>
-        </div>
-    {{/if}}
 
-    <h4 class="form-header"><a data-action="toggleSection" data-toggle-type="biography-bio">{{localize "CO.ui.biography"}}</a></h4>
+
+    <h4 class="form-header bio-notes-section"><a data-action="toggleSection" data-toggle-type="biography-bio"><i class="fa-solid fa-book-user"></i> {{localize "CO.ui.biography"}}</a></h4>
     <div class="bio notes foldable {{ifThen biographyBioExpanded 'expanded' 'folded'}}">
         <div class="notes-section">
             <label class="details-label">{{localize "CO.ui.public"}}</label>
@@ -97,7 +62,7 @@
         {{/if}}
     </div>
 
-    <h4 class="form-header"><a data-action="toggleSection" data-toggle-type="biography-appearance">{{localize "CO.ui.appearance"}}</a></h4>
+    <h4 class="form-header bio-appearance-section"><a data-action="toggleSection" data-toggle-type="biography-appearance"><i class="fa-solid fa-user-tie"></i> {{localize "CO.ui.appearance"}}</a></h4>
     <div class="appearance notes foldable {{ifThen biographyAppearanceExpanded 'expanded' 'folded'}}">
         <div class="notes-section">
             <label class="details-label">{{localize "CO.ui.public"}}</label>
@@ -114,4 +79,41 @@
             </div>
         {{/if}}
     </div>
+
+    {{#if viewLimited}}
+        <div class="form-group bio-size">
+            <label>{{localize "CO.ui.size"}}</label>
+            <div class="form-fields">
+                <select data-action="sizeChange" name="system.details.size" data-type="String" {{#unless unlocked}}disabled{{/unless}} style="width:100%" >
+                    {{selectOptions choiceSize selected=details.size localize=true}}
+                </select>
+            </div>
+        </div>    
+    {{else}}
+        <h4 class="form-header"><a data-action="toggleSection" data-toggle-type="biography-misc"><i class="fa-solid fa-person"></i> {{localize "CO.ui.misc"}}</a></h4>
+        <div class="misc foldable bio-misc {{ifThen biographyMiscExpanded 'expanded' 'folded'}}">
+            <div class="form-group bio-size">
+                <label>{{localize "CO.ui.size"}}</label>
+                <div class="form-fields">
+                    <select data-action="sizeChange" name="system.details.size" data-type="String" class="{{#unless unlocked}}disabled{{/unless}}" style="width:100%" >
+                        {{selectOptions choiceSize selected=details.size localize=true}}
+                    </select>
+                </div>
+            </div>
+            <div class="form-group bio-languages">
+                <label>{{localize "CO.ui.languages"}}</label>
+                <div class="form-fields">
+                <input
+                    class="field-value"
+                    name="system.details.languages"
+                    type="text"
+                    value="{{system.details.languages}}"
+                    placeholder="{{localize 'CO.ui.languages'}}"
+                    data-dtype="String"
+                    {{#unless unlocked}}readonly{{/unless}}
+                />
+                </div>
+            </div>
+        </div>
+    {{/if}}
 </section>


### PR DESCRIPTION
Un mise en page plus compacte pour l'onglet Biographie de la feuille de personnage.

1. Des icones Font-awesome pour les sections
2. un retrait de marges 
3. déplacement de la section Divers en bas de la fenêtre
4. mise sur la même ligne la taille et les langages