### PR TITLE
Corrige affichage capacité non apprise sur rencontre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.1.5
+
+## Corrections
+
+- Corrige l'affichage des capacités dans les rencontre qui ne s'affichaient plus si on decochais la case 'appris' (#412)
+
 # 2.1.4
 
 ## Améliorations

--- a/templates/actors/shared/capacities-nopath.hbs
+++ b/templates/actors/shared/capacities-nopath.hbs
@@ -52,7 +52,20 @@
                             </div>
                     {{/if}}                    
                 {{/if}}
-            {{/if}}
+            {{else}}
+                 {{#if @root.unlocked}}
+                    <li class="item flexrow" data-item-uuid="{{capacity.uuid}}" data-item-id="{{capacity._id}}" data-item-type="capacity" style="opacity: 40% ; font-style: Italic">                        
+                        <div class="item-name flexrow">
+                            <a class="item-img" data-action="editItem" style="background-image: url('{{capacity.img}}')" data-tooltip="{{capacity.enrichedTooltip}}"></a>
+                            <h4 data-tooltip="{{localize 'CO.notif.unknownCapacity'}}">{{capacity.name}}{{#if capacity.system.isSpell}} * {{/if}}{{#if capacity.system.hasActionType}} ({{capacity.system.actionTypeShortLabel}}){{/if}}</h4>
+                        </div>
+                        <div class="item-controls-2">
+                            <a class="edit" data-action="editItem" data-tooltip="{{localize 'CO.label.long.edit'}}"><i class="fas fa-fw fa-edit"></i></a>
+                            <a class="item-control" data-action="learnCapacity" data-tooltip="{{localize 'CO.ui.buy'}}"><i class="fa-solid gray fa-check"></i></a>
+                         </div>
+                    </li>
+                 {{/if}}
+             {{/if}}
         {{/each}}
     </ol>
 </ol>


### PR DESCRIPTION
Fix#412

Corrige l'affichage sur les rencontre ou lorsqu'on décochait la case "appris" la capacité disparaissait meme en mode edition.

<img width="1197" height="465" alt="image" src="https://github.com/user-attachments/assets/015c0a17-ec9e-4892-98db-e12609bf3d90" />

