### PR TITLE
Correction d'un problème de cases des Modifiers pour les Traits

### DIFF
--- a/css/co.css
+++ b/css/co.css
@@ -2153,16 +2153,16 @@ co-toggle-switch[checked] thumb {
 .theme-light .co.application.sheet.item.feature .modifiers-container .modifier {
   border: 1px solid var(--color-feature-light);
 }
-.co.application.sheet.item.feature .modifiers-container .modifier :nth-child(5),
-.co.application.sheet.item.feature .modifiers-container .modifier :nth-child(6) {
+.co.application.sheet.item.feature .modifiers-container .modifier .form-group:nth-last-child(2),
+.co.application.sheet.item.feature .modifiers-container .modifier .form-group:nth-last-child(3) {
   grid-column: auto / span 2;
 }
-.co.application.sheet.item.feature .modifiers-container .modifier :nth-child(5) label,
-.co.application.sheet.item.feature .modifiers-container .modifier :nth-child(6) label {
+.co.application.sheet.item.feature .modifiers-container .modifier .form-group:nth-last-child(2) label,
+.co.application.sheet.item.feature .modifiers-container .modifier .form-group:nth-last-child(3) label {
   flex: 2;
 }
-.co.application.sheet.item.feature .modifiers-container .modifier :nth-child(5) input[type="text"],
-.co.application.sheet.item.feature .modifiers-container .modifier :nth-child(6) input[type="text"] {
+.co.application.sheet.item.feature .modifiers-container .modifier .form-group:nth-last-child(2) input[type="text"],
+.co.application.sheet.item.feature .modifiers-container .modifier .form-group:nth-last-child(3) input[type="text"] {
   flex: 11;
 }
 .co.application.sheet.item.feature .modifiers-container .modifier input,

--- a/styles/applications/sheets/items/feature.less
+++ b/styles/applications/sheets/items/feature.less
@@ -74,8 +74,8 @@
       border: 1px solid var(--color-feature-light);
     }
 
-    :nth-child(5),
-    :nth-child(6) {
+    .form-group:nth-last-child(2),
+    .form-group:nth-last-child(3) {
       grid-column: auto / span 2;
 
       label {


### PR DESCRIPTION
La case des choix pour les Modificateurs des feuilles de Traits, en disparaissant au moment d'être placée sur une feuille de personnage, réorganisait la grille des éléments et cassait la mise en page.
Basée sur le CSS des feuilles de Profil, cette modification permet de faire disparaitre la case sans réorganiser les éléments (seulement en masquant la case de choix).