### PR TITLE
Ouverture des limitation de nouvel acteurs venant de modules tiers

### DIFF
--- a/co.mjs
+++ b/co.mjs
@@ -30,6 +30,7 @@ Hooks.once("init", async function () {
   CONFIG.Actor.documentClass = documents.COActor
 
   CONFIG.Actor.dataModels = {
+    ...(CONFIG.Actor.dataModels ?? {}),
     character: models.CharacterData,
     encounter: models.EncounterData,
   }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -71,6 +71,10 @@ export default class COActor extends Actor {
   getRollData() {
     const rollData = { ...this.system }
 
+    if (!["character", "encounter"].includes(this.type)) {
+      return rollData
+    }
+
     rollData.agi = this.system.abilities.agi.value
     rollData.for = this.system.abilities.for.value
     rollData.con = this.system.abilities.con.value


### PR DESCRIPTION
Une limitation du système ne permettait pas de créer d'autres types d'acteurs que les deux prévu pour co2. Pour permettre d'ajouter des acteurs venant d'un module par exemple.